### PR TITLE
generalized Makefile and test scripts for FreeBSD

### DIFF
--- a/tests/cout.sh
+++ b/tests/cout.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+: ${CC:="gcc"}
+
 LISP="tmp/foo-$$.scm"
 C1="tmp/foo-C1-$$.c"
 C2="tmp/foo-C2-$$.c"
@@ -9,7 +11,7 @@ OBJ="tmp/foo-$$"
 echo '(lambda (args) (print "kissa"))' > $LISP # <- halt with exit value 42
 
 # check that all compile silently and produce equal code
-$@ -x c -o $C1 $LISP && gcc -o $OBJ $C1 | 
+$@ -x c -o $C1 $LISP && $CC -o $OBJ $C1 |
 $@ -x c < $LISP > $C2 
 $@ -x c -o $C3 < $LISP 
 
@@ -18,6 +20,6 @@ diff $C1 $C2 || exit 1
 diff $C1 $C3 || exit 2
 
 # check that they work
-gcc -o $OBJ $C1 && ./$OBJ || exit 3
+$CC -o $OBJ $C1 && ./$OBJ || exit 3
 
 rm $LISP $C1 $C2 $C3 $OBJ

--- a/tests/no-threads.sh
+++ b/tests/no-threads.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+: ${CC:="gcc"}
+
 LISP="tmp/bare-$$.scm"
 FASL="tmp/bare-$$.fasl"
 C="tmp/bare-$$.c"
@@ -18,7 +20,7 @@ RFASL=$?
 echo "fasl: $RFASL"
 
 $@ --no-threads -o $C $LISP
-gcc -o $OBJ $C
+$CC -o $OBJ $C
 $OBJ
 RBIN=$?
 echo "binary: $RBIN"


### PR DESCRIPTION
A few changes to the Makefile:

- Create $(MANDIR) variable and also use $(BINDIR) in a few more places
- Add a "make all" target which is needed by the ports tree (and conventional anyway)
- Add CC=$(CC) before calls to test scripts, and add ": ${CC:="gcc"}" to some of the test scripts, so that if the user chooses an alternate compiler (eg, Clang), this will propagate to the test scripts. (That funky-looking line of shell code means that CC defaults to "gcc", but is overridden by whatever is in the environment, if anything is defined.)

- Change "rm" to "rm -f" in make clean to silence some noisy errors (not FreeBSD specific)
- Fix a typo in a comment

By generalizing MANDIR, BINDIR, and CC, it's easier to install on FreeBSD with a single-line "make" with a few options added, or by using a very minimal patch.
