### PR TITLE
Tweak parser to make lexical syntax more closely mirror R7RS

### DIFF
--- a/owl/sexp.scm
+++ b/owl/sexp.scm
@@ -35,7 +35,7 @@
       (define (between? lo x hi)
          (and (<= lo x) (<= x hi)))
 
-      (define special-symbol-chars (string->bytes "+-=<>!*%?_/"))
+      (define special-symbol-chars (string->bytes "+-=<>!*%?_/~&$^:@"))
 
       (define (symbol-lead-char? n) 
          (or 
@@ -46,7 +46,8 @@
 
       (define (symbol-char? n) 
          (or (symbol-lead-char? n) 
-            (or
+             (eq? n #\.)
+             (or
                (between? #\0 n #\9)
                (> n 127))))         ;; allow high code points in symbols
 


### PR DESCRIPTION
This is a very small change that brings the syntax of identifiers a little bit closer to R[567]RS identifiers. This came up because I was trying to run some [SXML-related code](http://okmij.org/ftp/Scheme/xml.html#SXML-spec) with Owl Lisp, and SXML expects `'@` to be a valid symbol, which it is not in Owl.

This is still not exactly RnRS-conformant, but it gets the parser closer with minimal changes. I'd be happy to sit down and modify the parser to understand the exact RnRS syntax, if that'd be a preferable pull request, but it would also make the parsing code moderately more complicated.