### PR TITLE
Fix a couple of typos in the README overview

### DIFF
--- a/README
+++ b/README
@@ -4,8 +4,8 @@ Copyright (c) 2016 Aki Helin
 OVERVIEW
 ~~~~~~~~
 
-Owl Lisp is a functtional dialect of the Scheme programming language. It
-is mainly based on applicative subset of the R7RS standard.
+Owl Lisp is a functional dialect of the Scheme programming language. It
+is mainly based on the applicative subset of the R7RS standard.
 
 
 REQUIREMENTS


### PR DESCRIPTION
This pull request fixes a couple of typos in the overview part of the README.

I made the assumption that Owl Lisp is based on "**the** applicative subset" of the R7RS standard instead of "**an** applicative subset".