### PR TITLE
Fix a typo in a bin/tada.scm comment string

### DIFF
--- a/bin/tada.scm
+++ b/bin/tada.scm
@@ -1,6 +1,6 @@
 #!/usr/bin/ol --run 
 
-;; totally automatic documentation aggrecator (TADA)
+;; totally automatic documentation aggregator (TADA)
 ;; initial minimal viable version
 ;; usage: tada owl-library.scm -> documentation
 


### PR DESCRIPTION
Change "aggre**c**ator" to "aggre**g**ator" in a bin/tada.scm comment string.