### PR TITLE
add setenv syscall + test

### DIFF
--- a/c/ovm.c
+++ b/c/ovm.c
@@ -135,6 +135,7 @@ void *realloc(void *ptr, size_t size);
 void *malloc(size_t size);
 void free(void *ptr);
 char *getenv(const char *name);
+int setenv(const char *name, const char *value, int overwrite);
 DIR *opendir(const char *name);
 DIR *fdopendir(int fd);
 pid_t fork(void);
@@ -874,7 +875,13 @@ static word prim_sys(int op, word a, word b, word c) {
          if (sendto(sock, data, nbytes, 0, (struct sockaddr *) &peer, sizeof(peer)) == -1)
             return IFALSE;
          return ITRUE; }
-      default: 
+      case 28: { /* setenv <owl-raw-bvec-or-ascii-leaf-string> <owl-raw-bvec-or-ascii-leaf-string> */
+         char *name = (char *)a;
+         if (!allocp(name)) return IFALSE;
+         char *val = (char *)b;
+         if (!allocp(val)) return IFALSE;
+         return (setenv(name + W, val + W, 1) ? IFALSE : ITRUE); }
+      default:
          return IFALSE;
    }
 }

--- a/owl/sys.scm
+++ b/owl/sys.scm
@@ -17,6 +17,7 @@
       chdir
       kill
       getenv
+      setenv
       unlink
       rmdir
       mkdir
@@ -221,5 +222,8 @@
                   (if bvec
                      (bytes->string (vec->list bvec))
                      #false))
-               #false)))))
+               #false)))
 
+      (define (setenv var val)
+        (sys-prim 28 (c-string var) (c-string val) #false))
+      ))

--- a/tests/env.scm
+++ b/tests/env.scm
@@ -1,0 +1,5 @@
+(import (owl sys))
+
+(print (getenv "FOO"))
+(setenv "FOO" "BAR")
+(print (getenv "FOO"))

--- a/tests/env.scm.ok
+++ b/tests/env.scm.ok
@@ -1,0 +1,2 @@
+#false
+BAR


### PR DESCRIPTION
Hi there,

here's an attempt to add a simple syscall. I added a basic test as well.

It seems to work, I copied the `getenv` piece blindly and used it. I'd love it if you gave a little explanation on each line. Like what's the `char *name = (char *)a` do? What's the `allocp` check? Why are you adding `W` to the `char *`s?