### PR TITLE
define 'string-append' to conform to R7RS, and replace nested usage

### DIFF
--- a/owl/string.scm
+++ b/owl/string.scm
@@ -305,7 +305,9 @@
                (string-eq-walk (str-iter a) (str-iter b))
                #false)))
 
-      (define string-append str-app)
+      (define (string-append . str)
+	(fold str-app "" str))
+
       (define string->list string->runes)
       (define list->string runes->string)
 

--- a/owl/symbol.scm
+++ b/owl/symbol.scm
@@ -22,6 +22,6 @@
                   ((string=? str "")
                      "||") ;; make empty symbols less invisible
                   ((m/ / str) ;; fixme: doesn't quote internal |:s yet
-                     (string-append (string-append "|" str) "|"))
+                     (string-append "|" str "|"))
                   (else str)))
             (error "Not a symbol: " x)))))

--- a/tests/hashbang.sh
+++ b/tests/hashbang.sh
@@ -3,7 +3,7 @@
 ME=$$
 HERE=$(pwd)
 
-echo '(lambda (args) (print (foldr string-append "" (list "#!" (foldr (lambda (a b) (if (equal? b "") a (string-append a (string-append " " b)))) "" (map (lambda (x) (string-append ' "\"$HERE/\"" ' x)) (cdr args))) "\n" "(print \"ohai\")"))))' | $@ --run - $@ > tmp/script-$ME
+echo '(lambda (args) (print (foldr string-append "" (list "#!" (foldr (lambda (a b) (if (equal? b "") a (string-append a " " b))) "" (map (lambda (x) (string-append ' "\"$HERE/\"" ' x)) (cdr args))) "\n" "(print \"ohai\")"))))' | $@ --run - $@ > tmp/script-$ME
 
 chmod +x tmp/script-$ME
 


### PR DESCRIPTION
According to R7RS (page 47), _string-append_ should accept an arbitrary number of strings. With this simple patch, Owl Lisp behaves like other Scheme implementations in this regard:

```
$ ./ol
You see a prompt.
> (string-append)
""
> (string-append "ab")
"ab"
> (string-append "ab" "cd")
"abcd"
> (string-append "ab" "cd" "ef")
"abcdef"
```