### PR TITLE
remove identical duplicate definitions within the same file

### DIFF
--- a/owl/defmac.scm
+++ b/owl/defmac.scm
@@ -474,7 +474,6 @@
       (define type-ff-black-leaf     8)
       (define type-symbol            4)
       (define type-tuple             2)
-      (define type-symbol            4)
       (define type-rlist-node       14)
       (define type-rlist-spine      10)
       (define type-string            3)

--- a/owl/env.scm
+++ b/owl/env.scm
@@ -201,8 +201,6 @@
          
       (define env-fold ff-fold)
 
-      (define env-del del)
-
       (define (tuple->list t)
         (let loop ((pos 1))
           (if (eq? pos (size t))

--- a/owl/io.scm
+++ b/owl/io.scm
@@ -526,16 +526,6 @@
                   ;(print "file->vector: cannot open " path)
                   #false))))
 
-      (define (file->list path) ; path -> vec | #false
-         (let ((port (maybe-open-file path)))
-            (if port
-               (let ((data (read-blocks->list port null)))
-                  (maybe-close-port port)
-                  data)
-               (begin
-                  ;(print "file->vector: cannot open " path)
-                  #false))))
-
       ;; write each leaf chunk separately (note, no raw type testing here -> can fail)
       (define (write-vector vec port)
          (let loop ((ll (vec-leaves vec)))

--- a/owl/primop.scm
+++ b/owl/primop.scm
@@ -251,12 +251,6 @@
       ;; make bytecode and intern it (to improve sharing, not mandatory)
       (define (bytes->bytecode bytes)
          (raw bytes type-bytecode #false))
-      
-      (define (app a b)
-         (if (eq? a '())
-            b
-            (cons (car a)
-               (app (cdr a) b))))
 
       ;; construct the arity check, just return #false on errors, since we don't have any IO or error throwing yet
       (define (bytecode-function fixed? arity bytes)


### PR DESCRIPTION
Possible candidates for further clean-up of (not identical) duplicates are in **owl/math.scm**:

`(define (add a b)`

and

`(define (numerator n)`

Maybe just rename the first **add** to **addi**?