### PR TITLE
adjust 'toggle_blocking' to address several issues

### DIFF
--- a/c/ovm.c
+++ b/c/ovm.c
@@ -307,10 +307,13 @@ static word *gc(int size, word *regs) {
 
 /*** OS Interaction and Helpers ***/
 
-void toggle_blocking(int sock, int blockp) {
-   fcntl(sock, F_SETFL, 
-      (fcntl(sock, F_GETFD) & (!O_NONBLOCK)) 
-         | (blockp ? 0 : O_NONBLOCK));
+void toggle_blocking(int fd, int blockp) {
+   int fl0 = fcntl(fd, F_GETFL);
+   if (fl0 != -1) {
+      int fl1 = (fl0 & ~O_NONBLOCK) | (blockp ? 0 : O_NONBLOCK);
+      if (fl0 != fl1)
+         fcntl(fd, F_SETFL, fl1);
+   }
 }
 
 void signal_handler(int signal) {


### PR DESCRIPTION
- use F_GETFL instead of F_GETFD to obtain the current flags
- don't operate on -1 (in case of an error)
- mask with bitwise NOT instead of logical negation
- run F_SETFL only, if the resulting flags differ