### PR TITLE
add sys-prims for file descriptor duplication, and for creating pipes

### DIFF
--- a/c/ovm.c
+++ b/c/ovm.c
@@ -820,6 +820,24 @@ static word prim_sys(int op, word a, word b, word c) {
          return (setenv(name + W, val + W, 1) ? IFALSE : ITRUE); }
       case 29:
          return prim_connect((word *) a, b, c);
+      case 30: { /* dupfd old-fd new-fd fixed → new-fd | #false */
+         int fd0 = fixval(a), fd1 = fixval(b);
+         fd1 = c != IFALSE ? dup2(fd0, fd1) : fcntl(fd0, F_DUPFD, fd1);
+         if (fd1 == -1)
+            return IFALSE;
+         return F(fd1); }
+      case 31: { /* pipe → (read-fd . write-fd) | #false */
+         int fd[2];
+         word *pair;
+         if (pipe(fd) != 0)
+            return IFALSE;
+         toggle_blocking(fd[0], 0);
+         toggle_blocking(fd[1], 0);
+         allocate(3, pair);
+         pair[0] = PAIRHDR;
+         pair[1] = F(fd[0]);
+         pair[2] = F(fd[1]);
+         return (word)pair; }
       default:
          return IFALSE;
    }

--- a/owl/sys.scm
+++ b/owl/sys.scm
@@ -13,6 +13,7 @@
       dir->list-all
       exec
       fork
+      pipe
       wait
       chdir
       kill
@@ -43,7 +44,7 @@
       stderr
       fopen
       fclose
-      
+      dupfd
       set-terminal-rawness)
 
    (import
@@ -73,6 +74,10 @@
             ((c-string path) => 
                (λ (raw) (sys-prim 1 raw mode #false)))
             (else #false)))
+
+      ;; → (fixed ? fd == new-fd : fd >= new-fd) | #false
+      (define (dupfd old-fd new-fd fixed)
+         (sys-prim 30 old-fd new-fd fixed))
 
 
       ;;;
@@ -161,6 +166,10 @@
             (if (and path (all (λ (x) x) args))
                (sys-prim 17 path args #false)
                (cons path args))))
+
+      ;; → #false on failure, else '(read-fd . write-fd)
+      (define (pipe)
+         (sys-prim 31 #false #false #false))
 
       ;; → #false = fork failed, #true = ok, we're in child, n = ok, child pid is n
       (define (fork)

--- a/tests/process.scm.ok
+++ b/tests/process.scm.ok
@@ -3,4 +3,7 @@ forked child processes
 child exited with (1 . 42)
 child exited with (1 . 43)
 child exited with (1 . 44)
+starting sub-process
+hello from sub-process
+child exited with (1 . 0)
 done


### PR DESCRIPTION
these are especially useful for redirecting the stdin/stdout/stderr of sub-processes - empowering Owl Lisp for system scripting (-: