### PR TITLE
system primitives: replace 'mkdir' by the more universal 'mknod'

### DIFF
--- a/c/ovm.c
+++ b/c/ovm.c
@@ -777,8 +777,15 @@ static word prim_sys(int op, word a, word b, word c) {
          return BOOL(allocp(a) && unlink((char *)a + W) == 0);
       case 23: /* rmdir path → bool */
          return BOOL(allocp(a) && rmdir((char *)a + W) == 0);
-      case 24: /* mkdir path → bool */
-         return BOOL(allocp(a) && mkdir((char *)a + W, fixval(b)) == 0);
+      case 24: /* mknod path (type . mode) dev → bool */
+         if (allocp(a) && pairp(b)) {
+            const mode_t nods[4] = { S_IFIFO, S_IFCHR, S_IFBLK, S_IFREG };
+            const char *path = (const char *)a + W;
+            const mode_t type = fixval(G(b, 1)), mode = fixval(G(b, 2));
+            if ((type & ~3 ? mkdir(path, mode) : mknod(path, nods[type] | mode, fixval(c))) == 0)
+               return ITRUE;
+         }
+         return IFALSE;
       case 25: {
          int whence = fixval(c);
          off_t p = lseek(fixval(a), cnum(b), (whence == 0) ? SEEK_SET : ((whence == 1) ? SEEK_CUR : SEEK_END));

--- a/owl/sys.scm
+++ b/owl/sys.scm
@@ -28,7 +28,9 @@
       rename
       unlink
       rmdir
+      mknod
       mkdir
+      mkfifo
       directory?
       file?
       lseek
@@ -214,8 +216,14 @@
       (define (rmdir path)
          (sys-prim 23 path #false #false))
 
+      (define (mknod path type mode dev)
+         (sys-prim 24 (c-string path) (cons type mode) dev))
+
       (define (mkdir path mode)
-         (sys-prim 24 path mode #false))
+         (mknod path 4 mode 0))
+
+      (define (mkfifo path mode)
+         (mknod path 0 mode 0))
 
       (define (directory? path)
          (let ((dh (open-dir path)))


### PR DESCRIPTION
Tested on OpenBSD (S_IFREG fails there) and musl/Linux:
```
You see a prompt.
> (import (owl sys))
;; Imported (owl sys)
> (mkdir "test" #o755)
#true
> (chdir "test")
#true
> (umask #o000)
63
> (mkdir "dir" #o700)
#true
> (mkfifo "fifo" #o600)
#true
> (mknod "chr" 1 #o200 #x107)
#true
> (mknod "blk" 2 #o400 #x805)
#true
> (mknod "reg" 3 #o500 0)
#true
> (exec "/bin/ls" '("ls" "-l"))
total 0
br-------- 1 root root 8, 5 Apr  7 12:44 blk
c-w------- 1 root root 1, 7 Apr  7 12:44 chr
drwx------ 2 root root  256 Apr  7 12:44 dir
prw------- 1 root root    0 Apr  7 12:44 fifo
-r-x------ 1 root root    0 Apr  7 12:44 reg
```
