### PR TITLE
code de-duplication, unification, and minor fixes

### DIFF
--- a/owl/string.scm
+++ b/owl/string.scm
@@ -313,19 +313,19 @@
                (list->string (list . things)))))
 
       (define (c-string str) ; -> bvec | #false
-         (if (eq? (type str) type-string)
+         (raw
+            (str-foldr
             ;; do not re-encode raw strings. these are normally ASCII strings 
             ;; which would not need encoding anyway, but explicitly bypass it 
             ;; to allow these strings to contain *invalid string data*. This 
             ;; allows bad non UTF-8 strings coming for example from command 
             ;; line arguments (like paths having invalid encoding) to be used 
             ;; for opening files.
-            (raw (str-foldr cons '(0) str) type-string #false)
-            (let ((bs (str-foldr encode-point '(0) str)))
-               ; check that the UTF-8 encoded version fits one raw chunk (64KB)
-               (if (<= (length bs) #xffff) 
-                  (raw bs type-string #false)
-                  #false))))
+               (if (eq? (type str) type-string)
+                  cons
+                  encode-point)
+               '(0) str)
+            type-string #false))
 
       (define null-terminate c-string)
 

--- a/owl/sys.scm
+++ b/owl/sys.scm
@@ -273,10 +273,8 @@
       ;;; Environment variables
       ;;;
 
-      ;; str → bvec | F
       (define (getenv str)
-         (let ((bvec (sys 16 str)))
-            (and bvec (bytes->string (vector->list bvec)))))
+         (sys 16 str))
 
       (define (setenv var val)
          (sys 28 var val))


### PR DESCRIPTION
- don't use FMAX when calculating the maximum payload length
- use raw-strings for all OS input (args, env, paths)
- make onum() independent from the value in FBITS
- with readdir(), distinguish between EOF and error
- fix size calculation in count_cmdlinearg_words()