### PR TITLE
 get rid of the 3rd parameter in 'raw'

### DIFF
--- a/c/ovm.c
+++ b/c/ovm.c
@@ -1450,9 +1450,8 @@ invoke: /* nargs and regs ready, maybe gc and execute ob */
       A2 = F(res>>FBITS);
       A3 = F(res&FMAX);
       NEXT(4); }
-   op60: /* lraw lst type dir r (fixme, alloc amount testing compiler pass not in place yet!) */
-      A3 = prim_lraw(A0, fixval(A1));
-      NEXT(4);
+   op60: /* unused */
+      error(256, F(60), IFALSE);
    op61: /* clock <secs> <ticks> */ { /* fixme: sys */
       struct timeval tp;
       word *ob;

--- a/c/ovm.c
+++ b/c/ovm.c
@@ -872,12 +872,11 @@ static word prim_sys(int op, word a, word b, word c) {
    }
 }
 
-static word prim_lraw(word wptr, int type, word revp) {
+static word prim_lraw(word wptr, int type) {
    word *lst = (word *) wptr;
    byte *pos;
    word *raw, *ob;
    unsigned int len = 0;
-   if (revp != IFALSE) { exit(1); } /* <- to be removed */
    for (ob = lst; pairp(ob); ob = (word *)ob[2])
       len++;
    if ((word)ob != INULL || len > MAXPAYL)
@@ -1314,8 +1313,9 @@ invoke: /* nargs and regs ready, maybe gc and execute ob */
       word *ob = (word *) R[ip[0]];
       R[ip[1]] = (immediatep(ob)) ? IFALSE : F(hdrsize(*ob)-1);
       NEXT(2); }
-   op37: /* unused */
-      error(256, F(37), IFALSE);
+   op37: /* lraw lst type r (FIXME: alloc amount testing compiler pass not in place yet) */
+      A2 = prim_lraw(A0, fixval(A1));
+      NEXT(3);
    op38: { /* fx+ a b r o, types prechecked, signs ignored, assume fixnumbits+1 fits to machine word */
       word res = fixval(A0) + fixval(A1);
       word low = res & FMAX;
@@ -1451,7 +1451,7 @@ invoke: /* nargs and regs ready, maybe gc and execute ob */
       A3 = F(res&FMAX);
       NEXT(4); }
    op60: /* lraw lst type dir r (fixme, alloc amount testing compiler pass not in place yet!) */
-      A3 = prim_lraw(A0, fixval(A1), A2);
+      A3 = prim_lraw(A0, fixval(A1));
       NEXT(4);
    op61: /* clock <secs> <ticks> */ { /* fixme: sys */
       struct timeval tp;

--- a/owl/assemble.scm
+++ b/owl/assemble.scm
@@ -264,7 +264,7 @@
 
       ;; make bytecode and intern it (to improve sharing, not mandatory)
       (define (bytes->bytecode bytes)
-         (interact 'intern (raw bytes type-bytecode #false)))
+         (interact 'intern (raw2 bytes type-bytecode)))
 
       ; code rtl object -> executable code
       ;; todo: exit via fail cont

--- a/owl/assemble.scm
+++ b/owl/assemble.scm
@@ -264,7 +264,7 @@
 
       ;; make bytecode and intern it (to improve sharing, not mandatory)
       (define (bytes->bytecode bytes)
-         (interact 'intern (raw2 bytes type-bytecode)))
+         (interact 'intern (raw bytes type-bytecode)))
 
       ; code rtl object -> executable code
       ;; todo: exit via fail cont

--- a/owl/cgen.scm
+++ b/owl/cgen.scm
@@ -152,7 +152,7 @@
       ;; lraw lst-reg type-reg flipp-reg to
       (define (cify-lraw bs regs fail) 
          (lets ((lr tr fr to bs (get4 (cdr bs))))
-            (values (list "R["to"]=prim_lraw(R["lr"],fixval(R["tr"]),R["fr"]);") bs    
+            (values (list "R["to"]=prim_lraw(R["lr"],fixval(R["tr"]));") bs
                (del regs to)))) ; <- lraw can fail
 
       ;; ref ob pos to

--- a/owl/dump.scm
+++ b/owl/dump.scm
@@ -200,7 +200,7 @@
                      ((compile-to-c (car obs) extras) =>
                         (λ (src)
                            (lets
-                              ((wrapper (raw2 (list 0 (>> code 8) (band code 255)) type-bytecode)))
+                              ((wrapper (raw (list 0 (>> code 8) (band code 255)) type-bytecode)))
                               (loop (+ code 1) (cdr obs)
                                  (cons (cons (car obs) (tuple code wrapper src)) out)))))
                      (else
@@ -253,7 +253,7 @@
                (let ((bytes (map (λ (p) (refb bc p)) (iota 0 1 (sizeb bc)))))
                   (if (eq? (cadr bytes) 0)
                      (error "bug: vm speciazation instruction probably referencing code from current vm: " bytes))
-                  (raw2 bytes type-bytecode))))) ; <- reallocate it
+                  (raw bytes type-bytecode))))) ; <- reallocate it
 
       (define (original-sources native-ops extras)
          (ff-fold

--- a/owl/dump.scm
+++ b/owl/dump.scm
@@ -199,8 +199,8 @@
                            "report this as an issue if this happens for a real program."))
                      ((compile-to-c (car obs) extras) =>
                         (λ (src)
-                           (lets 
-                              ((wrapper (raw (list 0 (>> code 8) (band code 255)) type-bytecode #false)))
+                           (lets
+                              ((wrapper (raw2 (list 0 (>> code 8) (band code 255)) type-bytecode)))
                               (loop (+ code 1) (cdr obs)
                                  (cons (cons (car obs) (tuple code wrapper src)) out)))))
                      (else
@@ -253,7 +253,7 @@
                (let ((bytes (map (λ (p) (refb bc p)) (iota 0 1 (sizeb bc)))))
                   (if (eq? (cadr bytes) 0)
                      (error "bug: vm speciazation instruction probably referencing code from current vm: " bytes))
-                  (raw bytes type-bytecode #false))))) ; <- reallocate it
+                  (raw2 bytes type-bytecode))))) ; <- reallocate it
 
       (define (original-sources native-ops extras)
          (ff-fold

--- a/owl/eval.scm
+++ b/owl/eval.scm
@@ -96,7 +96,7 @@
             ;; note that these could now come straight from primops
             '(cons car cdr eq? type type-old size cast fetch ref sys-prim refb
               pick mk mkr sys fxbor fxbxor fread _fopen fclose fsend lraw
-              raw _sopen accept mkt bind set lesser? call-native
+              raw2 raw _sopen accept mkt bind set lesser? call-native
               mkred mkblack ff-bind ff-toggle ffcar ffcdr red? listuple
               fxband fx+ fxqr fx* fx- fx<< fx>> ncons ncar ncdr raw-mode
               iomux clock time sizeb getev type-byte)))

--- a/owl/eval.scm
+++ b/owl/eval.scm
@@ -87,16 +87,16 @@
                (make-transformer
                   '(define-syntax syntax-rules add quote)
                   '(
-                     ((define-syntax keyword 
+                     ((define-syntax keyword
                         (syntax-rules literals (pattern template) ...))
                   ()
-                  (quote syntax-operation add #false 
-                        (keyword literals (pattern ...) 
+                  (quote syntax-operation add #false
+                        (keyword literals (pattern ...)
                         (template ...)))))))
             ;; note that these could now come straight from primops
             '(cons car cdr eq? type type-old size cast fetch ref sys-prim refb
               pick mk mkr sys fxbor fxbxor fread _fopen fclose fsend lraw
-              raw2 raw _sopen accept mkt bind set lesser? call-native
+              raw _sopen accept mkt bind set lesser? call-native
               mkred mkblack ff-bind ff-toggle ffcar ffcdr red? listuple
               fxband fx+ fxqr fx* fx- fx<< fx>> ncons ncar ncdr raw-mode
               iomux clock time sizeb getev type-byte)))

--- a/owl/fasl.scm
+++ b/owl/fasl.scm
@@ -323,7 +323,7 @@
                             (ll size (get-nat ll fail 0))
                             (foo (if (> size 65535) (fail "bad raw object size")))
                             (ll rbytes (get-bytes ll size fail null))
-                            (obj (raw (reverse rbytes) type #false)))
+                            (obj (raw2 (reverse rbytes) type)))
                            (decoder ll (rcons obj got) fail)))
                      ((eq? kind 0) ;; fasl stream end marker 
                         ;; object done
@@ -334,7 +334,7 @@
                             (ll size (get-nat ll fail 0))
                             (foo (if (> size 65535) (fail "bad raw object size")))
                             (ll rbytes (get-bytes ll size fail null))
-                            (obj (raw (reverse rbytes) type #false)))
+                            (obj (raw2 (reverse rbytes) type)))
                            (decoder ll (rcons obj got) fail)))
                      (else
                         (fail (list "unknown object tag: " kind))))))

--- a/owl/fasl.scm
+++ b/owl/fasl.scm
@@ -323,7 +323,7 @@
                             (ll size (get-nat ll fail 0))
                             (foo (if (> size 65535) (fail "bad raw object size")))
                             (ll rbytes (get-bytes ll size fail null))
-                            (obj (raw2 (reverse rbytes) type)))
+                            (obj (raw (reverse rbytes) type)))
                            (decoder ll (rcons obj got) fail)))
                      ((eq? kind 0) ;; fasl stream end marker 
                         ;; object done
@@ -334,7 +334,7 @@
                             (ll size (get-nat ll fail 0))
                             (foo (if (> size 65535) (fail "bad raw object size")))
                             (ll rbytes (get-bytes ll size fail null))
-                            (obj (raw2 (reverse rbytes) type)))
+                            (obj (raw (reverse rbytes) type)))
                            (decoder ll (rcons obj got) fail)))
                      (else
                         (fail (list "unknown object tag: " kind))))))

--- a/owl/io.scm
+++ b/owl/io.scm
@@ -121,7 +121,7 @@
 
       ;; #[0 1 .. n .. m] n → #[n .. m]
       (define (bvec-tail bvec n)
-         (raw (map (lambda (p) (refb bvec p)) (iota n 1 (sizeb bvec))) type-vector-raw #false))
+         (raw2 (map (lambda (p) (refb bvec p)) (iota n 1 (sizeb bvec))) type-vector-raw))
 
       (define (try-write-block fd bvec len)
          (cond
@@ -394,10 +394,10 @@
          (cond
             ((eq? len output-buffer-size)
                (and 
-                  (write-really (raw (reverse out) type-vector-raw #false) fd)
+                  (write-really (raw2 (reverse out) type-vector-raw) fd)
                   (printer lst 0 null fd)))
             ((null? lst)
-               (write-really (raw (reverse out) type-vector-raw #false) fd))
+               (write-really (raw2 (reverse out) type-vector-raw) fd))
             (else
                ;; avoid dependency on generic math in IO
                (lets ((len _ (fx+ len 1)))

--- a/owl/io.scm
+++ b/owl/io.scm
@@ -121,7 +121,7 @@
 
       ;; #[0 1 .. n .. m] n → #[n .. m]
       (define (bvec-tail bvec n)
-         (raw2 (map (lambda (p) (refb bvec p)) (iota n 1 (sizeb bvec))) type-vector-raw))
+         (raw (map (lambda (p) (refb bvec p)) (iota n 1 (sizeb bvec))) type-vector-raw))
 
       (define (try-write-block fd bvec len)
          (cond
@@ -393,11 +393,11 @@
       (define (printer lst len out fd)
          (cond
             ((eq? len output-buffer-size)
-               (and 
-                  (write-really (raw2 (reverse out) type-vector-raw) fd)
+               (and
+                  (write-really (raw (reverse out) type-vector-raw) fd)
                   (printer lst 0 null fd)))
             ((null? lst)
-               (write-really (raw2 (reverse out) type-vector-raw) fd))
+               (write-really (raw (reverse out) type-vector-raw) fd))
             (else
                ;; avoid dependency on generic math in IO
                (lets ((len _ (fx+ len 1)))

--- a/owl/primop.scm
+++ b/owl/primop.scm
@@ -39,7 +39,7 @@
    (begin
 
       (define (bytes->bytecode bytes)
-         (raw2 bytes type-bytecode))
+         (raw bytes type-bytecode))
 
       (define eq? 
          (bytes->bytecode 
@@ -133,7 +133,6 @@
             ;;; input arity includes a continuation
             (tuple 'sys          27 4 1 sys)
             (tuple 'sizeb        28 1 1 sizeb)   ;; raw-obj -> numbe of bytes (fixnum)
-            (tuple 'raw2         37 2 1 raw)   ;; make raw object, and *add padding byte count to type variant*
             (tuple 'raw          37 2 1 raw)   ;; make raw object, and *add padding byte count to type variant*
             (tuple 'cons         51 2 1 cons)
             (tuple 'car          52 1 1 car)

--- a/owl/primop.scm
+++ b/owl/primop.scm
@@ -39,7 +39,7 @@
    (begin
 
       (define (bytes->bytecode bytes)
-         (raw bytes type-bytecode #false))
+         (raw2 bytes type-bytecode))
 
       (define eq? 
          (bytes->bytecode 
@@ -98,7 +98,6 @@
       (define sys         (func '(4 27 4 5 6 7 24 7)))
       (define sizeb       (func '(2 28 4 5 24 5)))
       (define raw         (func '(3 37 4 5 6 24 6)))
-      (define old-raw     (func '(4 60 4 5 6 7 24 7)))
       (define _poll2      (func '(4 9 3 11 11 4 5 6 3 4 2 11 2))) 
       (define fxband      (func '(3 55 4 5 6 24 6)))
       (define fxbor       (func '(3 56 4 5 6 24 6)))
@@ -135,7 +134,7 @@
             (tuple 'sys          27 4 1 sys)
             (tuple 'sizeb        28 1 1 sizeb)   ;; raw-obj -> numbe of bytes (fixnum)
             (tuple 'raw2         37 2 1 raw)   ;; make raw object, and *add padding byte count to type variant*
-            (tuple 'raw          60 3 1 old-raw) ;; temporarily, for back-wards compatibility
+            (tuple 'raw          37 2 1 raw)   ;; make raw object, and *add padding byte count to type variant*
             (tuple 'cons         51 2 1 cons)
             (tuple 'car          52 1 1 car)
             (tuple 'cdr          53 1 1 cdr)

--- a/owl/primop.scm
+++ b/owl/primop.scm
@@ -97,7 +97,8 @@
       (define clock       (func '(1 9 3 5 61 3 4 2 5 2)))
       (define sys         (func '(4 27 4 5 6 7 24 7)))
       (define sizeb       (func '(2 28 4 5 24 5)))
-      (define raw         (func '(4 60 4 5 6 7 24 7)))
+      (define raw         (func '(3 37 4 5 6 24 6)))
+      (define old-raw     (func '(4 60 4 5 6 7 24 7)))
       (define _poll2      (func '(4 9 3 11 11 4 5 6 3 4 2 11 2))) 
       (define fxband      (func '(3 55 4 5 6 24 6)))
       (define fxbor       (func '(3 56 4 5 6 24 6)))
@@ -133,7 +134,8 @@
             ;;; input arity includes a continuation
             (tuple 'sys          27 4 1 sys)
             (tuple 'sizeb        28 1 1 sizeb)   ;; raw-obj -> numbe of bytes (fixnum)
-            (tuple 'raw          60 3 1 raw)   ;; make raw object, and *add padding byte count to type variant*
+            (tuple 'raw2         37 2 1 raw)   ;; make raw object, and *add padding byte count to type variant*
+            (tuple 'raw          60 3 1 old-raw) ;; temporarily, for back-wards compatibility
             (tuple 'cons         51 2 1 cons)
             (tuple 'car          52 1 1 car)
             (tuple 'cdr          53 1 1 cdr)

--- a/owl/random.scm
+++ b/owl/random.scm
@@ -479,8 +479,8 @@
       (define (random-bvec rs n)
          (let loop ((rs rs) (out null) (n n))
             (if (eq? n 0)
-               (values rs (raw2 (reverse out) type-vector-raw)) ; reverses to keep order
-               (lets 
+               (values rs (raw (reverse out) type-vector-raw)) ; reverses to keep order
+               (lets
                   ((d rs (uncons rs 0))
                    (n _ (fx- n 1))) 
                   (loop rs (cons (fxband d 255) out) n)))))

--- a/owl/random.scm
+++ b/owl/random.scm
@@ -479,7 +479,7 @@
       (define (random-bvec rs n)
          (let loop ((rs rs) (out null) (n n))
             (if (eq? n 0)
-               (values rs (raw out type-vector-raw #true)) ; reverses to keep order
+               (values rs (raw (reverse out) type-vector-raw #false)) ; reverses to keep order
                (lets 
                   ((d rs (uncons rs 0))
                    (n _ (fx- n 1))) 

--- a/owl/random.scm
+++ b/owl/random.scm
@@ -479,7 +479,7 @@
       (define (random-bvec rs n)
          (let loop ((rs rs) (out null) (n n))
             (if (eq? n 0)
-               (values rs (raw (reverse out) type-vector-raw #false)) ; reverses to keep order
+               (values rs (raw2 (reverse out) type-vector-raw)) ; reverses to keep order
                (lets 
                   ((d rs (uncons rs 0))
                    (n _ (fx- n 1))) 

--- a/owl/string.scm
+++ b/owl/string.scm
@@ -228,7 +228,7 @@
 
       (define (make-chunk rcps len ascii?)
          (if ascii?
-            (let ((str (raw (reverse rcps) type-string #false)))
+            (let ((str (raw2 (reverse rcps) type-string)))
                (if str
                   str
                   (error "Failed to make string: " rcps)))
@@ -313,7 +313,7 @@
                (list->string (list . things)))))
 
       (define (c-string str) ; -> bvec | #false
-         (raw
+         (raw2
             (str-foldr
             ;; do not re-encode raw strings. these are normally ASCII strings 
             ;; which would not need encoding anyway, but explicitly bypass it 
@@ -325,7 +325,7 @@
                   cons
                   encode-point)
                '(0) str)
-            type-string #false))
+            type-string))
 
       (define null-terminate c-string)
 

--- a/owl/string.scm
+++ b/owl/string.scm
@@ -228,7 +228,7 @@
 
       (define (make-chunk rcps len ascii?)
          (if ascii?
-            (let ((str (raw2 (reverse rcps) type-string)))
+            (let ((str (raw (reverse rcps) type-string)))
                (if str
                   str
                   (error "Failed to make string: " rcps)))
@@ -313,7 +313,7 @@
                (list->string (list . things)))))
 
       (define (c-string str) ; -> bvec | #false
-         (raw2
+         (raw
             (str-foldr
             ;; do not re-encode raw strings. these are normally ASCII strings 
             ;; which would not need encoding anyway, but explicitly bypass it 

--- a/owl/vector.scm
+++ b/owl/vector.scm
@@ -216,10 +216,10 @@
       ; note, a blank vector must use a raw one, since there are no such things as 0-tuples
 
       (define empty-vector 
-         (raw null type-vector-raw #false))
+         (raw2 null type-vector-raw))
 
       (define (list->byte-vector bs)
-         (raw bs type-vector-raw #false))
+         (raw2 bs type-vector-raw))
 
       (define (make-leaf rvals n raw?)
          (if raw?

--- a/owl/vector.scm
+++ b/owl/vector.scm
@@ -215,11 +215,11 @@
 
       ; note, a blank vector must use a raw one, since there are no such things as 0-tuples
 
-      (define empty-vector 
-         (raw2 null type-vector-raw))
+      (define empty-vector
+         (raw null type-vector-raw))
 
       (define (list->byte-vector bs)
-         (raw2 bs type-vector-raw))
+         (raw bs type-vector-raw))
 
       (define (make-leaf rvals n raw?)
          (if raw?


### PR DESCRIPTION
Okay, seems that I finally figured it out. Thanks for your hints!

Each single commit should be pulled separately, and a new init.fasl be pushed after every step. Here is what the single commits do:

part 1: get the **raw2** into the fasl, but continue to use **raw** because only that one is in the current init.fasl (ol.scm needs it in the first round)

part 2: now that **raw2** is in init.fasl, we can switch all calls of **raw** to it, and make **raw** an alias of **raw2**

part 3: now that the new **raw** is in init.fasl, we can rename all calls to **raw2** back to **raw**, and remove **raw2**