### PR TITLE
 add a curry function

### DIFF
--- a/owl/compile.scm
+++ b/owl/compile.scm
@@ -423,8 +423,8 @@
                (else #false))))
 
       (define null-value? (value-pred null?))
-      (define false-value? (value-pred (λ (x) (eq? x #false))))
-      (define zero-value? (value-pred (λ (x) (eq? x 0))))
+      (define false-value? (value-pred (c eq? #f)))
+      (define zero-value? (value-pred zero?))
 
       (define (simple-first a b cont)
          (cond
@@ -522,7 +522,7 @@
                         ((lambda formals body)
                            (if (opcode-arity-ok? op (length (cdr rands)))
                               (rtl-primitive regs op formals (cdr rands)
-                                 (λ (regs) (rtl-any regs body)))
+                                 (c rtl-any body))
                               ;; fixme: should be a way to show just parts of AST nodes, which may look odd
                               (error "Bad number of arguments for primitive: "
                                  (list 'op (primop-name op) 'got (length (cdr rands)) 'arguments))))

--- a/owl/compile.scm
+++ b/owl/compile.scm
@@ -4,9 +4,9 @@
 
 (define-library (owl compile)
 
-   (export 
+   (export
       compile
-      primops 
+      primops
       prim-opcodes)
 
    (import
@@ -81,9 +81,9 @@
                   ((eq? subtype (ref this 1))
                      (or
                         (find-any (cdr regs) sym type subtype)
-                        (let 
-                           ((sub 
-                              (index-of sym (ref this 2) 2)))   
+                        (let
+                           ((sub
+                              (index-of sym (ref this 2) 2)))
                            ;; FIXME, 2 will not be correct for shared envs
                            (if sub
                               (cons (ref this 3) sub)
@@ -233,7 +233,7 @@
             (if (null? args)
                (error "rtl-primitive: no type for mkt" args)
                (begin
-                  (rtl-primitive regs 
+                  (rtl-primitive regs
                      (+ (<< op 8) (band (value-of (car args)) #xff))
                      formals (cdr args) cont)))
             (rtl-args regs args
@@ -316,8 +316,8 @@
          (lets
             ((call-prime (apply-saves saves free call))
              (call-prime (rtl-add-targets call-prime))
-             (call-prime 
-               (remove 
+             (call-prime
+               (remove
                   (λ (move) (eq? (car move) (cdr move)))
                   call-prime))
              (call-prime (sort (λ (a b) (< (car a) (car b))) call-prime))
@@ -334,10 +334,9 @@
             (λ (ret)
                (or
                   (lfor #false (subsets call)
-                     (λ (foo subset) 
+                     (λ (foo subset)
                         (cond
-                           ((rtl-try-saves subset free call rest)
-                              => (λ (call) (ret call)))
+                           ((rtl-try-saves subset free call rest) => ret)
                            (else #false))))
                   ; has never happened in practice
                   (error "failed to compile call: " call)))))
@@ -402,7 +401,7 @@
                      ;   (error "Bad operator: " rator))
                      #false ;; <- can't remember why we're not failing here. changed while adding variable arity?
                      )))
-            (else 
+            (else
                ;(print "XXXXXXXXXXXXXXXXXXXXXXX non value call " rator)
                ;(print "ENV:")
                ;(for-each (λ (x) (print " - " x)) regs)
@@ -414,7 +413,7 @@
          (rtl-args regs (cons rator rands)
             (λ (regs all)
                (let ((free (rtl-safe-registers (length all) all)))
-                  (rtl-jump (car all) (cdr all) free 
+                  (rtl-jump (car all) (cdr all) free
                      (rtl-pick-call regs rator (length rands)))))))
 
       (define (value-pred pred)
@@ -442,9 +441,9 @@
 
       ;; fixme: ??? O(n) search for opcode->primop. what the...
       (define (opcode->primop op)
-         (let 
+         (let
             ((node
-               (some 
+               (some
                   (λ (x) (if (eq? (ref x 2) op) x #false))
                   primops)))
             (if node node (error "Unknown primop: " op))))
@@ -470,19 +469,19 @@
                               ;; todo: convert jump-if-<val> rtl nodes to a single shared rtl node to avoid having to deal with them as separate instructions
                               ((null-value? a) ; jump-if-null (optimization)
                                  (rtl-simple regs b (λ (regs bp)
-                                    (let 
+                                    (let
                                        ((then (rtl-any regs then))
                                         (else (rtl-any regs else)))
                                        (tuple 'jn bp then else)))))
                               ((false-value? a) ; jump-if-false 
                                  (rtl-simple regs b (λ (regs bp)
-                                    (let 
+                                    (let
                                        ((then (rtl-any regs then))
                                         (else (rtl-any regs else)))
                                        (tuple 'jf bp then else)))))
                               ((zero-value? a) ; jump-if-false 
                                  (rtl-simple regs b (λ (regs bp)
-                                    (let 
+                                    (let
                                        ((then (rtl-any regs then))
                                         (else (rtl-any regs else)))
                                        (tuple 'jz bp then else)))))
@@ -498,16 +497,16 @@
                      ; FIXME check object size here (via meta)
                      (let ((b (extract-value b)))
                         (if (and (fixnum? b) (>= b 0) (< b 257))
-                           (rtl-simple regs a 
+                           (rtl-simple regs a
                               (λ (regs ap)
                                  (tuple-case then
                                     ((lambda formals body)
                                        (bind (rtl-bind regs formals)
                                           (λ (selected then-regs)
-                                             (let 
+                                             (let
                                                 ((then-body (rtl-any then-regs body))
                                                  (else (rtl-any regs else)))
-                                                (tuple 'jab ap b 
+                                                (tuple 'jab ap b
                                                    (tuple 'lambda selected then-body)
                                                    else)))))
                                     (else
@@ -525,7 +524,7 @@
                               (rtl-primitive regs op formals (cdr rands)
                                  (λ (regs) (rtl-any regs body)))
                               ;; fixme: should be a way to show just parts of AST nodes, which may look odd
-                              (error "Bad number of arguments for primitive: " 
+                              (error "Bad number of arguments for primitive: "
                                  (list 'op (primop-name op) 'got (length (cdr rands)) 'arguments))))
                         (else
                            (error "bad primitive args: " rands)))
@@ -579,11 +578,11 @@
 
       ;; rtl-procedure now passes the intended new form here - replace it later in the AST node also
       (define (rtl-plain-lambda rtl exp clos literals tail)
-         (tuple-case exp   
+         (tuple-case exp
             ((lambda-var fixed? formals body)
                (lets
                   ((exec
-                     (assemble-code 
+                     (assemble-code
                         (tuple 'code-var fixed?
                            (length formals)
                            (rtl-any (entry-regs clos literals formals) body))
@@ -592,7 +591,7 @@
                      exec ; #<bytecode> 
                      (list->proc (cons exec literals)))))
             ((lambda formals body) ;; to be deprecated
-               (rtl-plain-lambda rtl 
+               (rtl-plain-lambda rtl
                   (tuple 'lambda-var #true formals body)
                   clos literals tail))
             (else
@@ -608,22 +607,22 @@
                (bytecode->list (ref thing 1)))
             (else
                (error "bytecode->list: " thing))))
-            
+
       (define (rtl-case-lambda rtl exp clos literals)
          (tuple-case exp
             ((lambda-var fixed? formals body)
                (rtl-plain-lambda rtl exp clos literals null))
             ((lambda formals body) ;; soon to be deprecated
-               (rtl-case-lambda rtl 
+               (rtl-case-lambda rtl
                   (tuple 'lambda-var #true formals body)
                   clos literals))
             ((case-lambda func else)
                (rtl-plain-lambda rtl func clos literals
-                  (bytecode->list 
+                  (bytecode->list
                      (rtl-case-lambda rtl else clos literals))))
             (else
                (error "rtl-case-lambda: bad node " exp))))
-  
+
       ;; todo: separate closure nodes from lambdas now that the arity may vary
       ;; todo: control flow analysis time - if we can see what the arguments are here, the info could be used to make most continuation returns direct via known call opcodes, which could remove an important branch prediction killer
       ;;; proc = #(procedure-header <code-ptr> l0 ... ln)
@@ -639,7 +638,7 @@
                   (tuple 'lambda-var fixed? formals body)
                   clos (rtl-literals rtl-procedure literals) null))
             ((closure-case body clos literals)
-               (lets 
+               (lets
                   ((lits (rtl-literals rtl-procedure literals))
                    (body (rtl-case-lambda rtl-procedure body clos lits)))
                   body))

--- a/owl/defmac.scm
+++ b/owl/defmac.scm
@@ -13,7 +13,7 @@
       define-values
       define-record-type
       _record-values
-      not o i self
+      not c i o self
       type-complex
       type-rational
       type-int+
@@ -424,6 +424,8 @@
 
       ; (define call/cc  ('_sans_cps (λ (k f) (f k (λ (r a) (k a))))))
 
+      (define (c f y) (λ (x) (f x y)))
+
       (define (k x y) x)
 
 
@@ -513,7 +515,7 @@
                ;; next must cons accessor of field to tail, so need to lookup its position
                (_record-values find tag mk pred (x ...) fields tail field fields (2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)))
             ((_record-values find tag mk pred left fields tail key (key . rest) (pos . poss))
-               (_record-values emit tag mk pred left fields ((λ (x) (ref x pos)) . tail)))
+               (_record-values emit tag mk pred left fields ((c ref pos) . tail)))
             ((_record-values find tag mk pred left fields tail key (x . rest) (pos . poss))
                (_record-values find tag mk pred left fields tail key rest poss))
             ((_record-values find tag mk pred left fields tail key () (pos . poss))

--- a/owl/dump.scm
+++ b/owl/dump.scm
@@ -223,10 +223,8 @@
          (λ (obj)
             (cond
                ;; if chosen to be a macro instruction in the new vm, replace with new bytecode calling it
-               ((get native-ops obj #false) =>
-                  (λ (vals) 
-                     ; write a reference to the wrapper function instead of the original bytecode
-                     (ref vals 2)))
+               ;; write a reference to the wrapper function instead of the original bytecode
+               ((get native-ops obj #false) => (c ref 2))
                ;; if this is a macro instruction in the current system, convert back to vanilla bytecode, or the 
                ;; target machine won't understand this
                ((extended-opcode obj) =>

--- a/owl/fixedpoint.scm
+++ b/owl/fixedpoint.scm
@@ -114,7 +114,7 @@
                            (lambda (node) (has? partition (name-of node)))
                            deps))
                      null)))
-            
+
             (error "unable to resolve dependencies for mutual recursion. remaining bindings are " deps)))
 
       ;;; remove nodes and associated deps
@@ -188,16 +188,14 @@
                            (let ((sub-env (env-bind env formals)))
                               (mkcall rator
                                  (append
-                                    (map 
-                                       (lambda (arg) (carry-bindings arg sub-env))
-                                       rands)
+                                    (map (c carry-bindings sub-env) rands)
                                     (map mkvar deps)))))
                         (else
                            (mkcall (carry-bindings rator env)
-                              (map(lambda (exp) (carry-bindings exp env)) rands)))))
+                              (map (c carry-bindings env) rands)))))
                   (else
                      (mkcall (carry-bindings rator env)
-                        (map (lambda (exp) (carry-bindings exp env)) rands)))))
+                        (map (c carry-bindings env) rands)))))
             ((lambda formals body)
                (mklambda formals
                   (carry-bindings body
@@ -227,7 +225,7 @@
             ((value val) exp)
             ((values vals)
                (tuple 'values
-                  (map (lambda (exp) (carry-bindings exp env)) vals)))
+                  (map (c carry-bindings env) vals)))
             (else
                (error "carry-bindings: strage expression: " exp))))
 
@@ -394,7 +392,7 @@
 
       (define (unletrec exp env)
          (define (unletrec-list exps)
-            (map (lambda (exp) (unletrec exp env)) exps))
+            (map (c unletrec env) exps))
          (tuple-case exp
             ((var value) exp)
             ((call rator rands)
@@ -410,7 +408,7 @@
             ((rlambda names values body)
                (lets
                   ((env (env-bind env names))
-                   (handle (lambda (exp) (unletrec exp env))))
+                   (handle (c unletrec env)))
                   (compile-rlambda names (map handle values) (handle body) env)))
             ((receive op fn)
                (tuple 'receive (unletrec op env) (unletrec fn env)))
@@ -436,5 +434,4 @@
       (define (fix-points exp env)
          (let ((result (unletrec exp env)))
             (tuple 'ok result env)))
-
-   ))
+))

--- a/owl/fixedpoint.scm
+++ b/owl/fixedpoint.scm
@@ -21,7 +21,7 @@
       ; return the least score by pred 
       (define (least pred lst)
          (if (null? lst)
-            #false   
+            #false
             (cdr
                (fold
                   (λ (lead x)
@@ -59,7 +59,7 @@
                ((value val) found)
                ((values vals)
                   (walk-list vals bound found))
-               ((receive op fn) 
+               ((receive op fn)
                   (walk op bound
                      (walk fn bound found)))
                ((branch kind a b then else)
@@ -159,7 +159,7 @@
                   (tuple 'branch kind (walk a) (walk b) (walk then) (walk else)))
                ((receive op fn)
                   (tuple 'receive (walk op) (walk fn)))
-               ((values vals) 
+               ((values vals)
                   (tuple 'values (map walk vals)))
                ((value val) exp)
                ((var sym)
@@ -182,14 +182,13 @@
                      (tuple-case (lookup env sym)
                         ((recursive formals deps)
                            (if (not (= (length formals) (length rands)))
-                              (error 
+                              (error
                                  "Wrong number of arguments: "
                                  (list 'call exp 'expects formals)))
-                           (let ((sub-env (env-bind env formals)))
-                              (mkcall rator
-                                 (append
-                                    (map (c carry-bindings sub-env) rands)
-                                    (map mkvar deps)))))
+                           (mkcall rator
+                              (append
+                                 (map (c carry-bindings (env-bind env formals)) rands)
+                                 (map mkvar deps))))
                         (else
                            (mkcall (carry-bindings rator env)
                               (map (c carry-bindings env) rands)))))
@@ -215,9 +214,9 @@
             ((var sym)
                (tuple-case (lookup env sym)
                   ((recursive formals deps)
-                     (let 
-                        ((lexp 
-                           (mklambda formals 
+                     (let
+                        ((lexp
+                           (mklambda formals
                               (mkcall exp (map mkvar (append formals deps))))))
                         ; (print "carry-bindings: made local closure " lexp)
                         lexp))
@@ -268,7 +267,7 @@
             (tuple-case (pick-binding deps env)
 
                ; no dependecies, so bind with ((lambda (a ...) X) A ...)
-               ((trivial nodes) 
+               ((trivial nodes)
                   (make-bindings (map first nodes) (map second nodes)
                      (generate-bindings
                         (remove-deps (map first nodes) deps)
@@ -281,9 +280,9 @@
                         (fold
                            (lambda (env node)
                               (let ((formals (ref (value-of node) 2)))
-                                 (env-put-raw env  
-                                    (name-of node) 
-                                    (tuple 'recursive formals 
+                                 (env-put-raw env
+                                    (name-of node)
+                                    (tuple 'recursive formals
                                        (list (name-of node))))))
                            env nodes)))
                      ; bind all names to extended functions (think (let ((fakt (lambda (fakt x fakt) ...) ...))))
@@ -291,7 +290,7 @@
                         (map first nodes)
                         (handle-recursion nodes env-rec)
                         ; then in the body bind them to (let ((fakt (lambda (x) (fakt x fakt))) ...) ...)
-                        (let 
+                        (let
                            ((body
                               (generate-bindings
                                  (remove-deps (map first nodes) deps)
@@ -312,7 +311,7 @@
                            (fold
                               (lambda (body node)
                                  (lets ((name val deps node))
-                                    (carry-simple-recursion body name 
+                                    (carry-simple-recursion body name
                                        (append (ref val 2) deps)))) ; add self to args
                               body nodes)
                            ))))
@@ -326,16 +325,16 @@
                            (lambda (node)
                               (if (null? (diff (deps-of node) partition))
                                  (set-deps node partition)
-                                 (error 
-                                    "mutual recursion bug, partitions differ: " 
+                                 (error
+                                    "mutual recursion bug, partitions differ: "
                                     (list 'picked partition 'found node))))
                            nodes))
                       (env-rec
                         (fold
                            (lambda (env node)
                               (let ((formals (ref (value-of node) 2)))
-                                 (env-put-raw env 
-                                    (name-of node) 
+                                 (env-put-raw env
+                                    (name-of node)
                                     (tuple 'recursive formals partition))))
                            env nodes)))
                      (make-bindings
@@ -424,7 +423,7 @@
                    (else (unletrec else env)))
                   (tuple 'branch kind a b then else)))
             ((case-lambda func else)
-               (tuple 'case-lambda 
+               (tuple 'case-lambda
                   (unletrec func env)
                   (unletrec else env)))
             (else

--- a/owl/list-extra.scm
+++ b/owl/list-extra.scm
@@ -18,7 +18,7 @@
       (owl syscall))
 
    (begin
-      
+
       (define (lref lst pos)
          (cond
             ((null? lst) (error "lref: out of list" pos))
@@ -34,7 +34,7 @@
             (else
                (cons (car lst)
                   (lset (cdr lst) (- pos 1) val)))))
-      
+
       (define (ldel lst pos)
          (cond
             ((null? lst) (error "list-del: out of list, left " pos))
@@ -58,7 +58,7 @@
             (else
                (lets ((hd tl lst))
                   (cons hd (led tl (- pos 1) op))))))
-      
+
       ;; insert value to list at given position
       (define (lins lst pos val)
          (cond
@@ -72,10 +72,10 @@
          (lref '(a b c) 1) = 'b
          (lset '(a b c) 1 'x) = '(a x c)
          (ldel '(a b c) 1)  = '(a c)
-         (led '(1 2 3) 1 (λ (x) (* x 10))) =  '(1 20 3)
+         (led '(1 2 3) 1 (c * 10)) =  '(1 20 3)
          (ledn '(1 2 3) 1 (λ (lst) (cons 'x lst))) = '(1 x 2 3)
          (lins '(a b c) 1 'x) = '(a x b c))
-      
+
       (define (length lst)
          (fold (λ (n v) (+ n 1)) 0 lst))
 
@@ -99,7 +99,7 @@
          (take '(a) 100) = '(a)
          (drop '(a b c) 2) = '(c)
          (drop '(a) 100) = '())
-         
+
       (define (iota-up p s e)
          (if (< p e)
             (cons p (iota-up (+ p s) s e))
@@ -124,7 +124,7 @@
       (example
          (iota 0 1 5) = '(0 1 2 3 4)
          (iota 10 -2 0) = '(10 8 6 4 2))
-      
+
       (define (list-tail lst n)
          (if (eq? n 0)
             lst

--- a/owl/macro.scm
+++ b/owl/macro.scm
@@ -1,7 +1,7 @@
 ; already loaded when booting.
 
 (define-library (owl macro)
-   
+
    ; remove make-transformer when it is no longer referred 
    (export macro-expand match make-transformer)
 
@@ -38,8 +38,7 @@
                   (cons exp found))
                (else found)))
 
-         (lambda (exp)
-            (walk exp null)))
+         (c walk null))
 
 
       ;;;
@@ -181,7 +180,7 @@
                (else
                   ;; repetition of length 0 or n>1
                   (car opts)))))
-     
+
       ;; pop all bindings of length > 1 
       (define (pop-ellipsis dict)
          (map 
@@ -406,7 +405,4 @@
              (free (gensym exp))
              (exp free (expand exp env free abort)))
             (post-macro-expand exp env abort)))
-
-
 ))
-

--- a/owl/math.scm
+++ b/owl/math.scm
@@ -1251,8 +1251,7 @@
                    (bp (rmul-digit b f))
                    (ap (rev-sub a bp)))
                   (if ap (rrem ap b) a)))
-            ((rev-sub a b) =>
-               (lambda (ap) (rrem ap b)))
+            ((rev-sub a b) => (c rrem b))
             (else
                (lets
                   ((h o (fx+ (ncar b) 1))

--- a/owl/math.scm
+++ b/owl/math.scm
@@ -16,12 +16,12 @@
 
 (define-library (owl math)
 
-   (export 
+   (export
       number? fixnum? integer?
-      + - * = / 
-      << < <= = >= > >>   
+      + - * = /
+      << < <= = >= > >>
       band bor bxor
-      div ediv rem mod quotrem mod divmod 
+      div ediv rem mod quotrem mod divmod
       add nat-succ sub mul big-bad-args negate
       even? odd?
       gcd gcdl lcm
@@ -87,9 +87,9 @@
 
       (define (zero? x) (eq? x 0))
 
-      (define (fixnum? x) 
+      (define (fixnum? x)
          (let ((t (type x)))
-            (or 
+            (or
                (eq? t type-fix+)
                ;(eq? t type-fix-) ;; <- FIXME - breaks build, someone isn't expecting negative fixnums
                )))
@@ -108,7 +108,7 @@
       ;         (lets ((q1 q2 r (fxqr 0 a b)))
       ;            (values q2 r)))))
 
-      (define-syntax define-traced 
+      (define-syntax define-traced
          (syntax-rules ()
             ((define-traced (name arg ...) . whatever)
                (define (name arg ...)
@@ -122,7 +122,7 @@
                (ncdr num)
                (ncons (ncar num) to))))
 
-      (define-syntax nrev 
+      (define-syntax nrev
          (syntax-rules ()
             ((nrev num)
                (nrev-walk num null))))
@@ -184,7 +184,7 @@
                (case (type b)
                   (type-int+ (big-less a b #false))
                   (else #false)))
-            (type-int-   
+            (type-int-
                (case (type b)
                   (type-int-
                      (if (big-less a b #false) #false #true))
@@ -224,10 +224,10 @@
                   (else #false)))
             (type-complex
                (if (eq? (type b) type-complex)
-                  (and (= (ref a 1) (ref b 1)) 
+                  (and (= (ref a 1) (ref b 1))
                        (= (ref a 2) (ref b 2)))
                   #false))
-            (else 
+            (else
                (big-bad-args '= a b))))
 
       ; later just, is major type X
@@ -265,7 +265,7 @@
                   (else (error "Bad number: " a))))
             (else (error 'negative? a))))
 
-      (define positive? 
+      (define positive?
          (o not negative?))
 
       ;; RnRS compat
@@ -308,7 +308,7 @@
                      (loop (ncdr n) (nat-succ i)))))))
 
       (define (add-number-big a big)
-         (lets 
+         (lets
             ((b bs big)
              (new overflow? (fx+ a b)))
             (if overflow?
@@ -336,8 +336,8 @@
                      (ncons r
                         (add-big (ncdr a) (ncdr b) o)))))))
 
-      (define-syntax add-small->positive 
-         (syntax-rules () 
+      (define-syntax add-small->positive
+         (syntax-rules ()
             ((add-small->positive a b)
                (lets ((r overflow? (fx+ a b)))
                   (if overflow? (ncons r *big-one*) r)))))
@@ -374,7 +374,7 @@
                      (if (eq? tail null)
                         (if leading? r #false)
                         (ncons r tail))))
-               (else 
+               (else
                   (ncons r (ncdr a))))))
 
       ; a - B = a + -B = -(-a + B) = -(B - a)
@@ -425,7 +425,7 @@
 
       (define (sub-big a b)
          (cond
-            ((big-less a b #false) 
+            ((big-less a b #false)
                (let ((neg (sub-digits b a #false #true)))
                   (cond
                      ((eq? neg 0) neg)
@@ -444,7 +444,7 @@
 
 
       ; for changing the (default positive) sign of unsigned operations 
-      (define-syntax negative 
+      (define-syntax negative
          (syntax-rules (imm cast if fix+)
             ((negative (op . args))
                (let ((foo (op . args)))
@@ -458,9 +458,9 @@
          (syntax-rules ()
             ((rational a b) (mkt type-rational a b))))
 
-      (define (negate num)   
+      (define (negate num)
          (case (type num)
-            (type-fix+ 
+            (type-fix+
                (if (eq? num 0)
                   0
                   (cast num type-fix-)))   ;; a  -> -a
@@ -511,7 +511,7 @@
                   (type-int+ (sub-big b a))                     ;; -A + +B == +B + -A -> as above
                   (type-int- (cast (add-big a b #false) type-int-))      ;; -A + -B == -(A + B)
                   (else (big-bad-args 'add a b))))
-            (else 
+            (else
                (big-bad-args 'add a b))))
 
       ; substraction is just just opencoded (+ a (negate b))
@@ -547,7 +547,7 @@
                   (type-int+ (cast (add-big a b #false) type-int-))         ;; -A - +B -> as -A + -B
                   (type-int- (sub-big b a))                     ;; -A - -B -> as -A + +B
                   (else (big-bad-args '- a b))))
-            (else 
+            (else
                (big-bad-args '- a b))))
 
 
@@ -577,12 +577,12 @@
                         (tail (ncons this tail))
                         ((eq? this 0)
                            (if first? 0 #false))
-                        (else 
-                           (if first? this 
+                        (else
+                           (if first? this
                               (ncons this null)))))))))
 
       (define (shift-right a n)
-         (if (eq? a null) 
+         (if (eq? a null)
             0
             (lets ((hi lo (fx>> (ncar a) n)))
                (shift-right-walk hi (ncdr a) n #true))))
@@ -602,7 +602,7 @@
          (case (type b)
             (type-fix+
                (lets ((_ wor bits (fxqr 0 b *fixnum-bits*)))
-                  (if (eq? wor 0) 
+                  (if (eq? wor 0)
                      (case (type a)
                         (type-fix+ (receive (fx>> a bits) (lambda (hi lo) hi)))
                         (type-fix- (receive (fx>> a bits) (lambda (hi lo) (if (eq? hi 0) 0 (negate hi)))))
@@ -613,8 +613,8 @@
                         (type-fix+ 0)
                         (type-fix- 0)
                         (type-int+ (shift-right (drop-digits a wor) bits))
-                        (type-int- 
-                           (negative 
+                        (type-int-
+                           (negative
                               (shift-right (drop-digits a wor) bits)))
                         (else (big-bad-args '>> a b))))))
             (type-int+
@@ -658,21 +658,21 @@
                                  lo
                                  (extend-digits (ncons lo null) words))
                               (if (eq? words 0)
-                                 (ncons lo (ncons hi null)) 
-                                 (extend-digits 
-                                    (ncons lo (ncons hi null)) 
+                                 (ncons lo (ncons hi null))
+                                 (extend-digits
+                                    (ncons lo (ncons hi null))
                                     words)))))
                      (type-fix-
                         (lets ((hi lo (fx<< a bits)))
                            (if (eq? hi 0)
                               (if (eq? words 0)
                                  (cast lo type-fix-)
-                                 (cast 
-                                    (extend-digits (ncons lo null) words) 
+                                 (cast
+                                    (extend-digits (ncons lo null) words)
                                     type-int-))
-                              (cast 
-                                 (extend-digits 
-                                    (ncons lo (ncons hi null)) words) 
+                              (cast
+                                 (extend-digits
+                                    (ncons lo (ncons hi null)) words)
                                  type-int-))))
                      (type-int+
                         (extend-digits (shift-left a bits 0) words))
@@ -733,7 +733,7 @@
          (let ((r (big-bxor-digits a b)))
             (cond
                ;; maybe demote to fixnum
-               ((null? r) 0) 
+               ((null? r) 0)
                ((null? (ncdr r)) (ncar r))
                (else r))))
 
@@ -765,7 +765,7 @@
             (type-fix+
                (case (type b)
                   (type-fix+ (fxbor a b))
-                  (type-int+ 
+                  (type-int+
                      (ncons (fxbor a (ncar b))
                         (ncdr b)))
                   (else
@@ -787,7 +787,7 @@
             (type-fix+
                (case (type b)
                   (type-fix+ (fxbxor a b))
-                  (type-int+ 
+                  (type-int+
                      (ncons (fxbxor a (ncar b)) (ncdr b)))
                   (else
                      (big-bad-args 'bxor a b))))
@@ -885,7 +885,8 @@
       (define (mul-simple a b)
          (if (null? a)
             null
-            (lets ((digit (ncar a))
+            (lets
+               ((digit (ncar a))
                 (head (ncons 0 (mul-simple (ncdr a) b)))
                 (this (mult-num-big digit b 0)))
                (addi head this))))
@@ -896,7 +897,7 @@
 
       ; drop leading zeros, reverse digits and downgrade to fixnum if possible
       (define (fixr n)
-         (if (null? n) 
+         (if (null? n)
             0
             (lets ((d ds n))
                (cond
@@ -914,8 +915,8 @@
             (s?
                (splice-nums (ncdr ah) (ncdr bh) at bt rat rbt #false l))
             (else
-               (lets 
-                  ((a at at) 
+               (lets
+                  ((a at at)
                    (b bt bt)
                    (l over (fx+ l 1))) ; fixme, no bignum len
                   (splice-nums (ncdr ah) (ncdr bh)
@@ -932,7 +933,7 @@
             ;; O(n) or O(1) leaf cases
             ((eq? (type a) type-fix+) (if (eq? (type b) type-fix+) (mult-fixnums a b) (mult-num-big a b 0)))
             ((eq? (type b) type-fix+) (mult-num-big b a 0))
-            ((null? (ncdr a)) 
+            ((null? (ncdr a))
                (if (null? (ncdr b))
                   (mult-fixnums (ncar a) (ncar b))
                   (mult-num-big (ncar a) b 0)))
@@ -944,7 +945,7 @@
                   ; 3O(n)
                   ((ah at bh bt atl
                      (splice-nums a b a b null null #true 0)))
-                  (if (lesser? atl 30) 
+                  (if (lesser? atl 30)
                      (mul-simple a b)
                      (lets
                          ; 3F(O(n/2)) + 2O(n/2)
@@ -965,7 +966,7 @@
       (define mult-big kara)
 
       (define (muli a b)
-         (cond 
+         (cond
             ; are these actually useful?
             ((eq? a 0) 0)
             ;((eq? a 1) b)
@@ -994,7 +995,7 @@
                         (type-int+ (mult-big a b))               ; +A * +B -> +C
                         (type-int- (cast (mult-big a b) type-int-))      ; +A * -B -> -C
                         (else (big-bad-args 'mul a b))))
-                  (type-int-   
+                  (type-int-
                      (case (type b)
                         (type-fix+ (cast (mult-num-big b a 0) type-int-))      ; -A * +b -> -C
                         (type-fix- (mult-num-big b a 0))               ; -A * -b -> +C
@@ -1022,7 +1023,7 @@
             ((eq? (type b) type-rational)
                ; a < b/b' <=> ab' < b
                (int< (muli a (ncdr b)) (ncar b)))
-            (else 
+            (else
                (int< a b))))
 
       (define (denominator n)
@@ -1045,8 +1046,6 @@
       ;;;
       ;;; DIVISION 
       ;;;
-
-
 
       ; walk down a and compute each digit of quotient using the top 2 digits of a
       (define (qr-bs-loop a1 as b out)
@@ -1071,7 +1070,7 @@
             ;   (let ((tl (ncdr a)))
             ;      (fxqr (ncar tl) (ncar a) b)))
             (else
-               (lets 
+               (lets
                   ((ra (nrev a))
                    (a as ra))
                   (qr-bs-loop a as b null)))))
@@ -1089,7 +1088,7 @@
             ((eq? n 0) 0)
             ((eq? a b) (subi n 1))
             ((lesser? b a) n)
-            (else 
+            (else
                (lets ((b over (fx>> b 1)))
                   (shift-local-down a b (subi n 1))))))
 
@@ -1098,14 +1097,14 @@
          (cond
             ((eq? a b) (subi n 1))
             ((lesser? a b) (subi n 1))
-            (else 
+            (else
                (lets ((over b (fx<< b 1)))
                   (if (eq? over 0)
                      (shift-local-up a b (nat-succ n))
                      (subi n 1))))))
 
       (define (div-shift a b n)
-         (if (eq? (type a) type-fix+)   
+         (if (eq? (type a) type-fix+)
             0
             (let ((na (ncdr a)) (nb (ncdr b)))
                (cond
@@ -1158,7 +1157,7 @@
 
 
 
-      ;;; 
+      ;;;
       ;;; REMAINDER
       ;;;
 
@@ -1212,7 +1211,7 @@
 
       (define (rev-sub a b) ; bignum format a' | #false
          (lets ((val fail? (rsub a b)))
-            (if fail? 
+            (if fail?
                #false
                (drop-zeros val))))
 
@@ -1222,7 +1221,7 @@
          (if (null? n)
             (values null 0)
             (lets
-               ((x tl n) 
+               ((x tl n)
                 (lo hi (fx* x d))
                 (tl carry (rmul (ncdr n) d))
                 (lo over (fx+ lo carry)))
@@ -1259,7 +1258,7 @@
                   ((h o (fx+ (ncar b) 1))
                    (f r (qr-big-small (ncons (ncar (ncdr a)) (ncons (ncar a) null)) h)) ; FIXME, use fxqr instead
                    )
-                  (if (eq? (type f) type-fix+) 
+                  (if (eq? (type f) type-fix+)
                      (lets
                         ((bp (rmul-digit b f))
                          (ap (rev-sub a bp))
@@ -1328,11 +1327,11 @@
             ((eq? a 0) (div-finish out))
             ((eq? (band a bit) 0) ; O(1)
                (if (eq? bp last-bit)
-                  (lets 
+                  (lets
                      ((a (ncdr a))
                       (a (if (null? (ncdr a)) (ncar a) a)))
                      (divex 1 0 a b (ncons 0 out)))
-                  (lets 
+                  (lets
                      ((_ bit (fx<< bit 1))
                       (bp _  (fx+ bp 1)))
                      (divex bit bp a b out))))
@@ -1346,7 +1345,7 @@
 
       (define (nat-divide-exact a b)
          (if (eq? (band b 1) 0)
-            (if (eq? (band a 1) 0) 
+            (if (eq? (band a 1) 0)
                ;; drop a powers of two from both and get 1 bit to bottom of b
                (nat-divide-exact (>> a 1) (>> b 1))
                #false) ;; not divisible
@@ -1423,7 +1422,7 @@
                      (type-fix- (lets ((q r (qr-big-small a b))) q))    ; -A / -b -> +c | +C
                      (type-int+ (div-big->negative (negate a) b))                     ; -A / +B -> 0 | -c | -C
                      (type-int- (div-big (negate a) (negate b)))                              ; -A / -B -> 0 | +c | +C
-                     (else (big-bad-args 'div a b))))   
+                     (else (big-bad-args 'div a b))))
                (else (big-bad-args 'div a b)))))
 
       (define-syntax fx%
@@ -1437,7 +1436,7 @@
                (case (type b)
                   (type-fix+ (fx% a b))
                   (type-fix- (fx% a b))
-                  (type-int+ a) 
+                  (type-int+ a)
                   (type-int- a)
                   (else (big-bad-args 'mod a b))))
             (type-fix-
@@ -1456,11 +1455,11 @@
                   (else (big-bad-args 'mod a b))))
             (type-int-
                (case (type b)
-                  (type-fix+ 
-                     (receive (qr-big-small a b) 
+                  (type-fix+
+                     (receive (qr-big-small a b)
                         (lambda (q r) (negate r))))
-                  (type-fix-    
-                     (receive (qr-big-small a b) 
+                  (type-fix-
+                     (receive (qr-big-small a b)
                         (lambda (q r) (negate r))))
                   (type-int+ (negate (nat-rem (negate a) b)))
                   (type-int- (negate (nat-rem (negate a) (negate b))))
@@ -1486,7 +1485,7 @@
          (if (eq? b 0)
             (big-bad-args 'quotrem a b)
             (case (type a)
-               (type-fix+ 
+               (type-fix+
                   (case (type b)
                      (type-fix+ (receive (fxqr 0 a b) (lambda (_ q r) (values q r))))
                      (type-int+ (values 0 a))
@@ -1498,26 +1497,26 @@
                      (type-fix+ (receive (qr-big-small a b) (lambda (q r) (values q r))))
                      (type-int+ (nat-quotrem a b))
                      (type-fix- (receive (qr-big-small a b) (lambda (q r) (values (negate q) r))))
-                     (type-int- (receive (nat-quotrem a (negate b)) 
+                     (type-int- (receive (nat-quotrem a (negate b))
                               (lambda (q r) (values (negate q) r))))
                      (else (big-bad-args 'quotrem a b))))
-               (type-fix- 
+               (type-fix-
                   (case (type b)
-                     (type-fix+ 
+                     (type-fix+
                         (receive (fxqr 0 a b) (lambda (_ q r) (values (negate q) (negate r)))))
                      (type-fix- (receive (fxqr 0 a b) (lambda (_ q r) (values q (negate r)))))
                      (type-int+ (values 0 a))
                      (type-int- (values 0 a))
-                     (else (big-bad-args 'quotrem a b))))   
+                     (else (big-bad-args 'quotrem a b))))
                (type-int-
                   (case (type b)
                      (type-fix+
                         (lets ((q r (qr-big-small a b)))
                            (values (negate q) (negate r))))
                      (type-fix- (receive (qr-big-small a b) (lambda (q r) (values q (negate r)))))
-                     (type-int+ (receive (nat-quotrem (negate a) b) 
+                     (type-int+ (receive (nat-quotrem (negate a) b)
                               (lambda (q r) (values (negate q) (negate r)))))
-                     (type-int- (receive (nat-quotrem (negate a) (negate b)) 
+                     (type-int- (receive (nat-quotrem (negate a) (negate b))
                               (lambda (q r) (values q (negate r)))))
                      (else (big-bad-args 'quotrem a b))))
                (else
@@ -1541,7 +1540,7 @@
 
       ; O(1), shift focus bit 
       (define (gcd-drop n)
-         (let ((s (car n)))   
+         (let ((s (car n)))
             (cond
                ((eq? s #x800000)
                   (let ((n (cdr n)))
@@ -1552,14 +1551,14 @@
                            (if (null? (ncdr tl))
                               (cons 1 (ncar tl))
                               (cons 1 tl))))))
-               (else   
+               (else
                   (lets ((hi lo (fx<< s 1)))
                      (cons lo (cdr n)))))))
 
       ;; FIXME - consider carrying these instead
       ;; FIXME depends on fixnum size
-      (define gcd-shifts 
-         (list->ff 
+      (define gcd-shifts
+         (list->ff
             (map (lambda (x) (cons (<< 1 x) x))
                '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23))))
 
@@ -1640,16 +1639,16 @@
             ((eq? (type b) type-fix-) (divide (negate a) (negate b)))
             ((eq? (type b) type-int-) (divide (negate a) (negate b)))
             ((divide-simple a b) => self)
-            (else 
+            (else
                (let ((f (gcd a b)))
                   (cond
-                     ((eq? f 1) 
+                     ((eq? f 1)
                         (if (eq? b 1)
                            a
                            (rational a b)))
                      ((= f b)
                         (divide-exact a f))
-                     (else 
+                     (else
                         (rational
                            (divide-exact a f)
                            (divide-exact b f))))))))
@@ -1665,7 +1664,7 @@
       ;; rational case: a/b + c, gcd(a,b) = 1 => gcd(a+bc, b) = 1 -> no need to renormalize
       (define (add a b)
          (case (type a)
-            (type-fix+ 
+            (type-fix+
                (case (type b)
                   (type-fix+  (add-small->positive a b))
                   (type-int+  (add-number-big a b))
@@ -1701,16 +1700,16 @@
                   (type-rational  (lets ((x z b)) (rational (add (muli a z) x) z)))
                   (type-complex (lets ((x y b)) (complex (add a x) y)))
                   (else (big-bad-args '+ a b))))
-            (type-rational 
+            (type-rational
                (case (type b)
                   (type-rational
                      ; a'/a" + b'/b" = a'b" + b'a" / a"b"
                      (let ((ad (ncdr a)) (bd (ncdr b)))
-                        (if (eq? ad bd)   
+                        (if (eq? ad bd)
                            ; a/x + b/x = (a+b)/x, x within fixnum range
                            (divide (add (ncar a) (ncar b)) ad)
-                           (let ((an (ncar a)) (bn (ncar b)))   
-                              (divide 
+                           (let ((an (ncar a)) (bn (ncar b)))
+                              (divide
                                  (add (muli an bd) (muli bn ad))
                                  (muli ad bd))))))
                   (type-complex
@@ -1722,7 +1721,7 @@
             (type-complex
                (if (eq? (type b) type-complex)
                   ;; A+ai + B+bi = A+B + (a+b)i
-                  (lets 
+                  (lets
                      ((ar ai a)
                       (br bi b)
                       (r (add ar br))
@@ -1731,7 +1730,7 @@
                   (lets
                      ((ar ai a))
                      (complex (add ar b) ai))))
-            (else 
+            (else
                (big-bad-args '+ a b))))
 
       (define (sub a b)
@@ -1774,14 +1773,14 @@
                   (else (big-bad-args '- a b))))
             (type-rational
                (case (type b)
-                  (type-rational 
+                  (type-rational
                      ; a'/a" - b'/b" = a'b" - b'a" / a"b"
                      (let ((ad (ncdr a)) (bd (ncdr b)))
-                        (if (eq? ad bd)   
+                        (if (eq? ad bd)
                            ; a/x - b/x = (a-b)/x, x within fixnum range
                            (divide (subi (ncar a) (ncar b)) ad)
-                           (let ((an (ncar a)) (bn (ncar b)))   
-                              (divide 
+                           (let ((an (ncar a)) (bn (ncar b)))
+                              (divide
                                  (subi (muli an bd) (muli bn ad))
                                  (muli ad bd))))))
                   (type-complex
@@ -1791,8 +1790,8 @@
                      (rational (subi (ncar a) (muli b (ncdr a))) (ncdr a)))))
             (type-complex
                (if (eq? (type b) type-complex)
-                  (lets 
-                     ((ar ai a) 
+                  (lets
+                     ((ar ai a)
                       (br bi b)
                       (r (sub ar br))
                       (i (sub ai bi)))
@@ -1822,7 +1821,7 @@
                         (type-fix- (negative (mult-fixnums a b)))      ; +a * -b
                         (type-int- (negative (mult-num-big a b 0)))    ; +a * -b
                         (type-rational  (divide (mul a (ncar b)) (ncdr b)))
-                        (type-complex 
+                        (type-complex
                            (lets ((br bi b) (r (mul a br)) (i (mul a bi)))
                               (if (eq? i 0) r (complex r i))))
                         (else (big-bad-args 'mul a b))))
@@ -1833,7 +1832,7 @@
                         (type-fix- (mult-fixnums a b))                  ; -a * -b -> +c | +C
                         (type-int- (mult-num-big a b 0))            ; -a * -B -> +C
                         (type-rational  (divide (mul a (ncar b)) (ncdr b)))
-                        (type-complex 
+                        (type-complex
                            (lets ((br bi b) (r (mul a br)) (i (mul a bi)))
                               (if (eq? i 0) r (complex r i))))
                         (else (big-bad-args 'mul a b))))
@@ -1844,33 +1843,33 @@
                         (type-fix- (cast (mult-num-big b a 0) type-int-))    ; +A * -b -> -C
                         (type-int- (cast (mult-big a b) type-int-))      ; +A * -B -> -C
                         (type-rational  (divide (mul a (ncar b)) (ncdr b)))
-                        (type-complex 
+                        (type-complex
                            (lets ((br bi b) (r (mul a br)) (i (mul a bi)))
                               (if (eq? i 0) r (complex r i))))
                         (else (big-bad-args 'mul a b))))
-                  (type-int-   
+                  (type-int-
                      (case (type b)
                         (type-fix+ (cast (mult-num-big b a 0) type-int-))      ; -A * +b -> -C
                         (type-int+ (cast (mult-big a b) type-int-))      ; -A * +B -> -C
                         (type-fix- (mult-num-big b a 0))               ; -A * -b -> +C
                         (type-int- (mult-big a b))                  ; -A * -B -> +C
                         (type-rational  (divide (mul a (ncar b)) (ncdr b)))
-                        (type-complex 
+                        (type-complex
                            (lets ((br bi b) (r (mul a br)) (i (mul a bi)))
                               (if (eq? i 0) r (complex r i))))
                         (else (big-bad-args 'mul a b))))
                   (type-rational
                      (case (type b)
-                        (type-rational  
+                        (type-rational
                            (divide (mul (ncar a) (ncar b)) (mul (ncdr a) (ncdr b))))
-                        (type-complex 
+                        (type-complex
                            (lets ((br bi b) (r (mul a br)) (i (mul a bi)))
                               (if (eq? i 0) r (complex r i))))
-                        (else 
+                        (else
                            (divide (mul (ncar a) b) (ncdr a)))))
-                  (type-complex 
+                  (type-complex
                      (if (eq? (type b) type-complex)
-                        (lets 
+                        (lets
                            ((ar ai a)
                             (br bi b)
                             (r (sub (mul ar br) (mul ai bi)))
@@ -1881,22 +1880,22 @@
                             (r (mul ar b))
                             (i (mul ai b)))
                            (if (eq? i 0) r (complex r i)))))
-                  (else 
+                  (else
                      (big-bad-args '* a b))))))
 
       ;; todo: division lacks short circuits
       (define (/ a b)
-         (cond    
+         (cond
             ((eq? b 0)
                (error "division by zero " (list '/ a b)))
             ((eq? (type a) type-complex)
                (if (eq? (type b) type-complex)
-                  (lets 
-                     ((ar ai a) 
+                  (lets
+                     ((ar ai a)
                       (br bi b)
                       (x (add (mul br br) (mul bi bi)))
                       (r (/ (add (mul ar br) (mul ai bi)) x))
-                      (i (/ (sub (mul ai br) (mul ar bi)) x))) 
+                      (i (/ (sub (mul ai br) (mul ar bi)) x)))
                      (if (eq? i 0) r (complex r i)))
                   (lets
                      ((ar ai a)
@@ -1905,7 +1904,7 @@
                       (i (/ (mul ai b) x)))
                      (if (eq? i 0) r (complex r i)))))
             ((eq? (type b) type-complex)
-               (lets 
+               (lets
                   ((br bi b)
                    (x (add (mul br br) (mul bi bi)))
                    (re (/ (mul a br) x))
@@ -1915,14 +1914,14 @@
                (if (eq? (type b) type-rational)
                   ; a'/a" / b'/b" = a'b" / a"b'
                   (divide
-                     (mul (ncar a) (ncdr b)) 
+                     (mul (ncar a) (ncdr b))
                      (mul (ncdr a) (ncar b)))
                   ; a'/a" / b = a'/ba"
                   (divide (ncar a) (mul (ncdr a) b))))
             ((eq? (type b) type-rational)
                ; a / b'/b" = ab"/n
                (divide (mul a (ncdr b)) (ncar b)))
-            (else 
+            (else
                (divide a b))))
 
 
@@ -2070,13 +2069,13 @@
       ;(test
       ;   (lmap (λ (i) (lets ((rst n (rand i #x20000))) n)) (lnums 1))
       ;   (λ (n) (log 2 n))
-      ;   (λ (n) (log2 n)))
+      ;   log2)
 
       ; note: it is safe to use div, which is faster for bignums, because by definition
       ; the product is divisble by the gcd. also, gcd 0 0 is not safe, but since (lcm 
       ; a a) == a, handlin this special case and and a small optimization overlap nicely.
 
-      (define (lcm a b) 
+      (define (lcm a b)
          (if (eq? a b)
             a
             (div (abs (mul a b)) (gcd a b))))
@@ -2090,7 +2089,7 @@
          (add digit (if (< digit 10) 48 87)))
 
       (define (render-digits num tl base)
-         (fold (λ (a b) (cons b a)) tl 
+         (fold (λ (a b) (cons b a)) tl
             (unfold (λ (n) (lets ((q r (quotrem n base))) (values (char-of r) q))) num zero?)))
 
       ;; move to math.scm
@@ -2105,7 +2104,7 @@
             ((eq? (type num) type-complex)
                ;; todo: imaginary number rendering looks silly, written in a hurry
                (lets ((real imag num))
-                  (render-number real 
+                  (render-number real
                      (cond
                         ((eq? imag 1) (ilist #\+ #\i tl))
                         ((eq? imag -1) (ilist #\- #\i tl))
@@ -2155,15 +2154,15 @@
 
       ;; - → sub
       (define -
-         (case-lambda 
+         (case-lambda
             ((a b) (sub a b))
             ((a) (sub 0 a))
-            ((a b . xs) 
+            ((a b . xs)
                (sub a (add b (fold add 0 xs))))))
 
       ;; * → mul
       (define *
-         (case-lambda 
+         (case-lambda
             ((a b) (mul a b))
             ((a b . xs) (mul a (mul b (fold mul 1 xs))))
             ((a) a)
@@ -2181,7 +2180,7 @@
       (define (each op x xs)
          (cond
             ((null? xs) #true)
-            ((op x (car xs)) 
+            ((op x (car xs))
                (each op (car xs) (cdr xs)))
             (else #false)))
 

--- a/owl/ol.scm
+++ b/owl/ol.scm
@@ -376,8 +376,7 @@ Check out https://github.com/aoh/owl-lisp for more information.")
                      (print "Owl Lisp " *owl-version*)
                      0)
                   ((getf dict 'about) (print about-owl) 0)
-                  ((getf dict 'load) =>
-                     (λ (path) (try-load-state path others)))
+                  ((getf dict 'load) => (c try-load-state others))
                   ((or (getf dict 'output) (getf dict 'output-format))
                      (if (< (length others) 2) ;; can take just one file or stdin
                         (repl-compile compiler env

--- a/owl/parse.scm
+++ b/owl/parse.scm
@@ -5,7 +5,7 @@
 ;; todo: reintroduce a better fail-func
 
 (define-library (owl parse)
-      
+
    (export
       let-parses
       byte
@@ -29,12 +29,12 @@
       ;; old compat names      
       get-imm get-byte get-kleene+ get-kleene* get-epsilon get-byte-between get-either
       get-byte-if get-rune get-rune-if get-greedy* get-greedy+ get-word
-     
+
       ;; old ones
       fd->exp-stream
       file->exp-stream
       )
-      
+
    (import
       (owl defmac)
       (owl lazy)
@@ -44,13 +44,12 @@
       (owl unicode)
       (owl io)
       (owl syscall))
-     
+
    (begin 
-      
-        
+
       ; (parser l r ok) → (ok l' r' val) | (backtrack l r why)
       ;   ... → l|#f r result|error
-      
+
       (define (backtrack l r reason)
          (if (null? l)
             (values #f r reason)
@@ -58,15 +57,15 @@
                (if (eq? (type hd) type-fix+)
                   (backtrack (cdr l) (cons hd r) reason)
                   (hd (cdr l) r reason)))))
-               
+
       (define eof-error "end of input")
-                  
+
       (define (byte l r ok)
          (cond
             ((null? r) (backtrack l r eof-error))
             ((pair? r) (ok (cons (car r) l) (cdr r) (car r)))
             (else      (byte l (r) ok))))
-      
+
       (define (imm x)
          (λ (l r ok)
             (cond
@@ -78,17 +77,17 @@
                      (backtrack l r 'bad-byte)))
                (else 
                   ((imm x) l (r) ok)))))
-      
+
       (define (ε val)
          (λ (l r ok)
             (ok l r val)))
-      
+
       (define epsilon ε)
-      
+
       (define (either a b)
          (λ (l r ok)
             (a (cons (λ (l r why) (b l r ok)) l) r ok)))
-               
+
       (define (seq a b)
          (λ (l r ok)
             (a l r
@@ -96,7 +95,7 @@
                   (b l r 
                      (λ (l r bv)
                         (ok l r (cons av bv))))))))
-      
+
       (define (star-vals a vals)
          (λ (l r ok)
             (a 
@@ -105,7 +104,7 @@
                 r 
                 (λ (l r val)
                    ((star-vals a (cons val vals)) l r ok)))))
-     
+
       (define (star a)
          (star-vals a null))
 
@@ -142,7 +141,7 @@
             ((let-parses ((a . b) ...) body)
                (λ (l r ok)
                   (let-parses 42 l r ok ((a . b) ...) body)))))
-      
+
       (define (greedy-star a)
          (greedy-star-vals a null) )
 
@@ -151,7 +150,7 @@
             ((first a)
              (rest (greedy-star a)))
             (cons first rest)))
-      
+
       (define (word s val)
          (let ((bytes (string->bytes s)))
             (λ (l r ok)
@@ -167,43 +166,42 @@
                            (backtrack l r "bad byte")))
                      (else
                         (loop l (r) left)))))))
-         
-       
-      
+
+
       (define-syntax any
          (syntax-rules ()
             ((any a) a)
             ((any a b) (either a b))
             ((any a b . c) (either a (any b . c)))))
-            
+
       (define (plus parser)
          (let-parses
             ((a parser)
              (as (star parser)))
             (cons a as)))
-      
+
       (define (byte-if pred)
          (let-parses
             ((a byte)
              (verify (pred a) "checked"))
             a))
-               
+
       ; #b10xxxxxx
       (define extension-byte 
          (let-parses
             ((b byte)
              (verify (eq? #b10000000 (fxband b #b11000000)) "Bad extension byte"))
             b))
-      
+
       (define (byte-between lo hi)
          (byte-if
             (λ (x)
                (and (lesser? lo x)
                     (lesser? x hi)))))
-            
+
       (define rune
          (any
-            (byte-if (λ (x) (lesser? x 128)))
+            (byte-if (c lesser? 128))
             (let-parses
                ((a (byte-between 127 224))
                 (verify (not (eq? a #b11000000)) "blank leading 2-byte char") ;; would be non-minimal
@@ -219,21 +217,20 @@
                 (verify (not (eq? a #b11110000)) "blank leading 4-byte char") ;; would be non-minimal
                 (b extension-byte) (c extension-byte) (d extension-byte))
                (four-byte-point a b c d))))
-      
-     
+
       (define (rune-if pred)
          (let-parses
             ((val rune)
              (verify (pred val) "bad rune"))
             val))
-        
+
       (define (parser-succ l r v)
          (values l r v))
-           
+
       (define (parse-head parser ll def)
          (lets ((l r val (parser null ll parser-succ)))
             (if l (cons val r) def)))
-     
+
       ; (parser l r ok) → (ok l' r' val) | (backtrack l r why)
       ;   ... → l|#f r result|error
       ;; prompt removed from here - it belongs elsewhere
@@ -252,7 +249,7 @@
                      ;; error handling being converted
                      ;(print-to stderr "fd->exp-stream: syntax error")
                      null)))))
-      
+
       (define (file->exp-stream path parser fail)
          ;(print "file->exp-stream: trying to open " path)
          (let ((fd (open-input-file path)))
@@ -260,7 +257,7 @@
             (if fd
                (fd->exp-stream fd parser fail)
                #false)))
-      
+
       (define get-imm imm)
       (define get-byte byte)
       (define get-byte-if byte-if)
@@ -274,7 +271,7 @@
       (define get-byte-between byte-between)
       (define get-either either)
       (define get-word word)
-       
+
       (define (try-parse parser data maybe-path maybe-error-msg fail-fn) 
          (lets ((l r val (parser null data parser-succ)))
             (cond
@@ -289,4 +286,3 @@
                   ;; full match
                   val))))
 ))
-      

--- a/owl/regex.scm
+++ b/owl/regex.scm
@@ -892,7 +892,7 @@
                (any
                   (let-parses ;; join tail of exp with implicit catenation
                      ((tl (get-catn get-regex)))
-                     (λ (head) (rex-and head tl)))
+                     (c rex-and tl))
                   (get-epsilon i)))) ;; nothing
            (tail (repetition regex))))
 

--- a/owl/regex.scm
+++ b/owl/regex.scm
@@ -36,9 +36,9 @@
 
    (begin
 
-      ;;; 
+      ;;;
       ;;; Matching functions
-      ;;; 
+      ;;;
 
       ;; the regexp is represented by a function which does stream matching
 
@@ -57,7 +57,7 @@
       (define (dot ls buff ms cont)
          (cond
             ((null? ls) #false)
-            ((pair? ls) 
+            ((pair? ls)
                (cont (cdr ls) (cons (car ls) buff) ms))
             (else (dot (ls) buff ms cont))))
 
@@ -70,7 +70,7 @@
                   (if (eq? (car ls) cp)
                      (cont (cdr ls) (cons cp buff) ms)
                      #false))
-               (else 
+               (else
                   (accept (ls) buff ms cont))))
          (if (eq? (type cp) type-fix+)
             accept
@@ -84,7 +84,7 @@
                   (if (fn (car ls))
                      (cont (cdr ls) (cons (car ls) buff) ms)
                      #false))
-               (else 
+               (else
                   (accept (ls) buff ms cont))))
          accept)
 
@@ -128,8 +128,8 @@
       (define (make-ff cs)
          (call/cc
             (λ (ret)
-               (fold 
-                  (λ (ff n) 
+               (fold
+                  (λ (ff n)
                      (if (eq? (type n) type-fix+)
                         (put ff n #true)
                         (ret #false))) ;; code point outside of fixnum range
@@ -140,24 +140,23 @@
          (cond
             ((null? cs) ;; should not come out of parser
                (error "empty char class: " cs))
-            (complement? 
+            (complement?
                ;; always use an iff for now in [^...]
                (reject-iff
-                  (fold 
+                  (fold
                      (λ (iff val) (iput iff val #true))
                      #empty cs)))
             ((null? (cdr cs))
                (imm (car cs)))
-            ((make-ff cs) =>
-               (λ (ff) (accept-ff ff)))
-            (else 
-               (accept-iff    
-                  (fold 
+            ((make-ff cs) => accept-ff)
+            (else
+               (accept-iff
+                  (fold
                      (λ (iff val) (iput iff val #true))
                      #empty cs)))))
 
       ;; <ra>|<rb>
-      (define (rex-or ra rb)  
+      (define (rex-or ra rb)
          (λ (ls buff ms cont)
             (or (ra ls buff ms cont)
                 (rb ls buff ms cont))))
@@ -165,7 +164,7 @@
       ;; <ra><rb>
       (define (rex-and ra rb)
          (λ (ls buff ms cont)
-            (ra ls buff ms 
+            (ra ls buff ms
                (λ (ls buff ms)
                   (rb ls buff ms cont)))))
 
@@ -197,7 +196,7 @@
       (define (alt-star rx)
          (define (collect ls buff ms cont)
             (or (cont ls buff ms)
-               (rx ls buff ms 
+               (rx ls buff ms
                   (λ (ls buff ms) (collect ls buff ms cont)))))
          collect)
 
@@ -234,7 +233,7 @@
                   (define (maybe ls buff ms n)
                      (if (eq? n 0)
                         (cont ls buff ms)
-                        (or 
+                        (or
                            (rx ls buff ms (λ (ls buff ms) (maybe ls buff ms (- n 1))))
                            (cont ls buff ms))))
                   (maybe ls buff ms n)))))
@@ -265,7 +264,7 @@
          (cond
             ((null? head) out)
             ((eq? head old) out)
-            (else 
+            (else
                (add-range (cdr head) old (cons (car head) out)))))
 
       ;; find node = (id . start-pos) in ms, and update the cdr to hold the range between buff and the start-pos
@@ -315,7 +314,7 @@
                   ((rex try rev ms (λ (ls buff ms) (null? ls)))
                      (cont ls buff ms))
                   ((null? rev) #false)
-                  (else 
+                  (else
                      (lets ((char rev rev))
                         (loop rev (cons char try))))))))
 
@@ -328,7 +327,7 @@
                      #false)
                   ((null? rev)
                      (cont ls buff ms))
-                  (else 
+                  (else
                      (lets ((char rev rev))
                         (loop rev (cons char try))))))))
 
@@ -372,11 +371,11 @@
       ;;; Running the regexen
       ;;;
 
-      (define start-node 
+      (define start-node
          (cons 0 null))
 
       ;; ranges = ((nth-range . start-node) ...)
-      (define blank-ranges 
+      (define blank-ranges
          (list start-node))
 
 
@@ -399,7 +398,7 @@
       ;; rex str → bool (if matches anywhere)
       (define (rex-match-anywhere? rex ll)
          (cond
-            ((null? ll) 
+            ((null? ll)
                (rex-match-prefix? rex ll))
             ((pair? ll)
                (if (rex-match-prefix? rex ll)
@@ -530,7 +529,7 @@
                   (let ((match (rex-match-prefix rex ll)))
                      (cond
                         (match
-                           (lets 
+                           (lets
                               ((ls buff ms match)
                                (ms (update-node ms start-node buff))) ;; save whole match to \0
                               (cond
@@ -550,7 +549,7 @@
                   (loop (ll))))))
 
       (define (make-replacer rex rep all? start?)
-         (λ (target) 
+         (λ (target)
             (cond
                ((string? target)
                   (runes->string (rex-replace (str-iter target) rex rep start? all?)))
@@ -560,22 +559,20 @@
       (define (rex-full-match ll rex)
          (let ((match (rex-match-prefix rex ll)))
             (if match
-               (lets 
+               (lets
                   ((ls buff ms match))
                   ;; check end of stream
                   (lets ((a ls (uncons ls #false)))
-                     (if a 
-                        #false
-                        ms)))
+                     (if a #false ms)))
                #false)))
 
       (define (make-full-match rex)
-         (λ (target) 
+         (λ (target)
             (cond
                ((string? target)
                   (let ((res (rex-full-match (str-iter target) rex)))
                      (if res
-                        (map (o runes->string cdr) 
+                        (map (o runes->string cdr)
                            (cdr (reverse res)))
                         #false)))
                (else
@@ -596,7 +593,7 @@
          (let-parses ((foo (get-imm 36))) fini))
 
       ;; maybe get a ?
-      (define get-altp 
+      (define get-altp
          (get-either (get-imm 63) (get-epsilon #false)))
 
       ;; todo: / or ?, and carry along in get-regex
@@ -604,22 +601,22 @@
          (get-imm #\/))
 
       ;; → (rex → rex')
-      (define get-star 
-         (let-parses 
+      (define get-star
+         (let-parses
             ((skip (get-imm 42))
              (altp get-altp))
             (if altp alt-star star)))
 
       ;; a+ = aa*
-      (define get-plus 
-         (let-parses 
+      (define get-plus
+         (let-parses
             ((skip (get-imm 43))
              (altp get-altp))
             (if altp alt-plus plus)))
 
       ;; a? = a{0,1} = (a|"")
-      (define get-quest 
-         (let-parses 
+      (define get-quest
+         (let-parses
             ((skip (get-imm 63))
              (altp get-altp))
             (if altp alt-quest quest)))
@@ -637,7 +634,7 @@
       (define space? (λ (b) (has? '(32 9 13 10 11 12) b)))
 
       ;; shared automata parts corresponding to predefined character classes
-      (define accept-digit (pred digit?)) 
+      (define accept-digit (pred digit?))
       (define accept-dot (imm 46))
       (define accept-nondigit (pred (λ (b) (not (digit? b)))))
       (define accept-alnum (pred alnum?))
@@ -674,14 +671,14 @@
 
       ;; strings are already sequences of unicode code points, so no need to decode here
       ;; accept any non-special char
-      (define get-plain-char 
-         (let-parses 
+      (define get-plain-char
+         (let-parses
             ((val get-byte) ;; really get-code-point since the input is already decoded
              (verify (not (has? special-chars val)) "bad special char"))
             (imm val)))
 
       (define (quoted-imm val)
-         (let-parses 
+         (let-parses
             ((quote (get-imm 92))
              (val (get-imm val)))
             val))
@@ -727,13 +724,13 @@
              (verify (char->hex b) #false))
             (char->hex b)))
 
-      (define get-8bit 
+      (define get-8bit
          (let-parses ((hi get-hex) (lo get-hex)) (bor (<< hi 4) lo)))
 
-      (define get-16bit 
+      (define get-16bit
          (let-parses ((hi get-8bit) (lo get-8bit)) (bor (<< hi 8) lo)))
 
-      (define get-32bit 
+      (define get-32bit
          (let-parses ((hi get-16bit) (lo get-16bit)) (bor (<< hi 16) lo)))
 
       ;; todo: what is the quotation used for 32-bit \xhhhhhhhh?
@@ -764,7 +761,7 @@
       ;; a quoted character or anything other than ]
       (define parse-char-class-char
          (get-either
-            parse-quoted-char 
+            parse-quoted-char
             (let-parses
                ((char get-byte)
                 (verify (not (eq? char 93)) #false))
@@ -804,22 +801,22 @@
             ((eq? m 'inf)
                (λ (rx) (at-least n rx)))
             ((= n m)
-               (if (eq? n 0) 
+               (if (eq? n 0)
                   epsilon
                   (λ (rx) (exactly n rx))))
             ((< n m) ;; <= enforced when parsing but ok to double-check as this is only done once 
-               (if (eq? n 0) 
+               (if (eq? n 0)
                   (λ (rx) (at-most m rx))
                   (λ (rx) (rex-and (exactly n rx) (at-most (- m n) rx)))))
             (else
                (error "make-repeater: bad range: " (list n 'to m)))))
 
-      (define get-range 
+      (define get-range
          (let-parses
             ((skip (get-imm 123))   ; <{>...}
-             (start  
+             (start
                (get-either get-number (get-epsilon 0))) ; <{[n]>...}
-             (end 
+             (end
                (get-either
                   (let-parses
                      ((skip (get-imm 44)) ; <{[n],>
@@ -881,7 +878,7 @@
                       (close (get-imm 41)))
                      (chunk rex))
                   get-char-class
-                  get-reference 
+                  get-reference
                   get-quoted-char
                   get-plain-char))
              (repetition
@@ -891,7 +888,7 @@
                   get-quest
                   get-range
                   (get-epsilon i)))
-             (tail 
+             (tail
                (any
                   (let-parses ;; join tail of exp with implicit catenation
                      ((tl (get-catn get-regex)))
@@ -907,7 +904,7 @@
             (fold rex-or hd tl)))
 
       (define get-matcher-regex
-         (let-parses 
+         (let-parses
             ((skip (get-imm #\m)) ;; [m]atch
              (skip (get-imm 47))  ;; opening /
              (start? (get-either (get-imm 94) (get-epsilon #false))) ;; maybe get leading ^ (special)
@@ -921,7 +918,7 @@
             (make-matcher (rex-and rex fini) #true)))
 
       (define get-copy-matcher-regex
-         (let-parses 
+         (let-parses
             ((skip (get-imm #\g)) ;; [g]rab
              (skip (get-imm 47))  ;; opening /
              (start? (get-either (get-imm 94) (get-epsilon #false))) ;; maybe get leading ^ (special)
@@ -930,7 +927,7 @@
             (make-copy-matcher rex start?)))
 
       (define get-cutter-regex
-         (let-parses 
+         (let-parses
             ((skip (get-imm 99))  ;; [c]ut
              (skip (get-imm 47))  ;; opening /
              (start? (get-either (get-imm 94) (get-epsilon #false))) ;; maybe get leading ^ (special)
@@ -939,7 +936,7 @@
             )
            (make-cutter rex start?)))
 
-      (define get-replace-char 
+      (define get-replace-char
          (get-either
             (let-parses ;; quoted
                ((skip (get-imm 92)) ;; \\
@@ -951,8 +948,8 @@
                char)))
 
       (define get-maybe-g
-         (get-either 
-            (get-imm 103) 
+         (get-either
+            (get-imm 103)
             (get-epsilon #false)))
 
       (define get-replace-regex

--- a/owl/register.scm
+++ b/owl/register.scm
@@ -47,7 +47,7 @@
       ; return a list of registers from uses (where the value has been moved to), or 
       ; some list of low registers if this one is outside the available ones
       (define (use-list uses reg)
-         (let ((opts (keep (λ (x) (< x highest-register)) (get uses reg null))))
+         (let ((opts (keep (c < highest-register) (get uses reg null))))
             (cond
                ((< reg highest-register)
                   opts)
@@ -306,5 +306,4 @@
       (define (allocate-registers rtl)
          (lets ((rtl usages (rtl-retard rtl)))
             rtl))
-         
-   ))
+))

--- a/owl/sort.scm
+++ b/owl/sort.scm
@@ -5,7 +5,7 @@
 
    (export sort isort quicksort mergesort)
 
-   (import 
+   (import
       (owl defmac)
       (owl math)
       (owl syscall)
@@ -17,12 +17,12 @@
       ;;; quicksort, never use this, worst case O(n^2) on sorted data
       ;;;
 
-      (define (quicksort op lst) 
+      (define (quicksort op lst)
          (let loop ((x lst))
-            (if (null? x) null 
-               (let ((this (car x))) 
+            (if (null? x) null
+               (let ((this (car x)))
                   (let diffx ((x (cdr x)) (left null) (right null))
-                     (cond 
+                     (cond
                         ((null? x)
                            (let ((left (loop left)))
                               (append left (cons this (loop right)))))
@@ -59,7 +59,7 @@
             (else (cons (car a) (merge op (cdr a) b)))))
 
       (define (merger op l)
-         (if (null? l) 
+         (if (null? l)
             null
             (let ((a (car l)) (l (cdr l)))
                (if (null? l)
@@ -67,7 +67,7 @@
                   (let ((b (car l)) (l (cdr l)))
                      (cons (merge op a b) (merger op l)))))))
 
-      ; as an optimization to (map (lambda (x) (list x)) l), chunk the list 
+      ; as an optimization to (map list l), chunk the list
       ; initially to <chunk-size> lists using insertion sort steps
 
       (define chunk-size 10)
@@ -89,7 +89,7 @@
             (merge-pairs op (merger op l))))
 
       (define (mergesort op l)
-         (if (null? l) 
+         (if (null? l)
             null
             (let ((l (chunker op l null 0)))
                (if (null? (cdr l))

--- a/owl/thread.scm
+++ b/owl/thread.scm
@@ -134,7 +134,7 @@
                (let ((state (put state return-value-tag 126)))
                   (drop-delivering todo done state id 
                      (tuple id (tuple 'crashed a b c)) tc)))
-            
+
             ; 4, fork
             (λ (id cont opts thunk todo done state tc)
                (lets 
@@ -177,14 +177,14 @@
                (tc tc 
                   (cons (tuple id (λ () (cont (and (null? todo) (null? done))))) todo)
                   done state))
-               
+
             ; 8, get running thread ids (sans self)
             (λ (id cont b c todo done state tc)
                (let 
                   ((ids
                      (append
-                        (map (λ (x) (ref x 1)) todo)
-                        (map (λ (x) (ref x 1)) done))))
+                        (map (c ref 1) todo)
+                        (map (c ref 1) done))))
                   (tc tc 
                      (cons 
                         (tuple id (λ () (cont ids)))
@@ -208,7 +208,7 @@
                   ;; tailcall signal handler and pass controller to allow resuming operation
                   ((get state signal-tag signal-halt) ; default to standard mcp 
                      all-threads state thread-controller)))
-            
+
             ; 11, reset mcp state (usually means exit from mcp repl)
             (λ (id cont threads state xtodo xdone xstate tc)
                ; (system-println "syscall 11 - swapping mcp state")
@@ -278,13 +278,13 @@
             ; 19, set return value proposal
             (λ (id cont b c todo done state tc)
                (tc tc (cons (tuple id (λ () (cont b))) todo) done (put state return-value-tag b)))
-           
+
             ;;; 20 & 21 change during profiling 
 
             ; 20, start profiling, no-op during profiling returning 'already-profiling
             (λ (id cont b c todo done state tc) 
                (tc tc (cons (tuple id (λ () (cont 'already-profiling))) todo) done state))
-            
+
             ; 21, end profiling, resume old ones, pass profiling info 
             (λ (id cont b c todo done state tc) 
                (lets
@@ -299,7 +299,7 @@
                (lets
                   ((por-state (tuple cont opts c)))
                   (tc tc (cons (tuple id por-state) todo) done state)))
-            
+
             ; 23, link thread
             (λ (id cont target c todo done state tc)
                (lets 

--- a/owl/variable.scm
+++ b/owl/variable.scm
@@ -1,5 +1,5 @@
 ;;;
-;;; Minimal thread-based pseudo-mutable values 
+;;; Minimal thread-based pseudo-mutable values
 ;;;
 
 (define-library (owl variable)
@@ -39,16 +39,16 @@
                         (store ((cdr msg) val)))
                      (else
                         (store val)))))))
-      
+
       (define (start-variable id val)
          (thread id (store val))
          (handler id))
-      
+
       (define make-variable
          (case-lambda
             ((id val) (start-variable id val))
             ((id) (start-variable id #false))
             (() (start-variable (list 'var) #false))))
-      
-      (define (link-variable id)
-         (handler id))))
+
+      (define link-variable handler)
+))

--- a/tests/bingo-rand.scm
+++ b/tests/bingo-rand.scm
@@ -16,7 +16,7 @@
          (wait-for msg))))
 
 ;; ff of all numbers
-(define wanted 
+(define wanted
    (fold (λ (ff n) (put ff n n)) empty (iota 0 1 n)))
 
 (define (drop-mails)
@@ -38,7 +38,7 @@
                (mail 'fini "i has all")
                (drop-mails))
             (else
-               (lets 
+               (lets
                   ((rst to  (rand rst n))
                    (rst num (rand rst n))
                    (rst rounds (rand rst 3)))
@@ -49,8 +49,7 @@
 (thread 'fini
    (begin
       (print (ref (wait-mail) 2)) ; omit the id to make output equal in all cases
-      (for-each (λ (id) (mail id 'halt)) 
-      (drop-mails))))
+      (for-each (c mail 'halt) (drop-mails))))
 
 (fold
    (λ (rst id)
@@ -62,6 +61,4 @@
    (iota 0 1 n))
 
 ;; start all threads
-(for-each
-   (λ (id) (mail id 'start))
-   (iota 0 1 n))
+(for-each (c mail 'start) (iota 0 1 n))

--- a/tests/mail-async-rand.scm
+++ b/tests/mail-async-rand.scm
@@ -43,5 +43,4 @@
    (seed->rands (* (time-ms) (<< (time-ms) 9)))
    (iota 0 2 n-threads))
 
-(for-each (λ (id) (mail id 'start)) (iota 0 1 n-threads))
-
+(for-each (c mail 'start) (iota 0 1 n-threads))

--- a/tests/rlist-rand.scm
+++ b/tests/rlist-rand.scm
@@ -39,15 +39,15 @@
 				((9 10) ; set a random element
 					(if (= len 0)
 						(list-test rst rl l len steps)
-						(lets 
+						(lets
 							((rst p (rand rst len))
 							 (rst v (rand rst 10000)))
 							;(print* (list "L[" p "] = " v))
 							(list-test rst (rset rl p v) (lset l p v) len steps))))
 				((11) ; map increment
 					(list-test rst
-						(rmap (lambda (x) (+ x 1)) rl)
-						(map (lambda (x) (+ x 1)) l)
+						(rmap (c + 1) rl)
+						(map (c + 1) l)
 						len steps))
 				((12) ; fold
 					(if (= (fold - 0 l) (rfold - 0 rl))


### PR DESCRIPTION
From what I've seen, the **C** term is usually defined as `(λ (f) (λ (y) (λ (x) (f x y))))`. But in my experience, this is rarely useful in Scheme. Most operations are binary (think of comparison or math), e.g. to create an incrementer, you would need to write `((c +) 1)` which it quite clumsy. Therefore I suggest to skip one sub-lambda and define it directly as `(λ (f y) (λ (x) (f x y)))`, so that the incrementer simply becomes `(c + 1)`.

I already converted some code to make use of it, for providing examples.