### PR TITLE
use capital letters for the standard terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ fasl/bootp.fasl
 fasl/ol.fasl
 tmp
 bin/ol
+bin/ol-old
 bin/vm

--- a/owl/args.scm
+++ b/owl/args.scm
@@ -1,6 +1,6 @@
 ;;;
 ;;; COMMAND LINE ARGUMENT HANDLER
-;;; 
+;;;
 
 (define-library (owl args)
 
@@ -27,13 +27,13 @@
       (scheme cxr))
 
    (begin
-      ;; cl-rules is a ff of 
+      ;; cl-rules is a ff of
       ;;   'short -> -x
       ;;   'long  -> --xylitol
 
       ;; str (rule-ff ..) → #false | rule-ff
       (define (select-rule string rules)
-         (if (null? rules) 
+         (if (null? rules)
             #false
             (let ((this (car rules)))
                (if (or (equal? string (getf this 'short))
@@ -58,7 +58,7 @@
       (define (undefined? ff key)
          (eq? blank (get ff key blank)))
 
-      (define (defined? ff key) 
+      (define (defined? ff key)
          (not (undefined? ff key)))
 
       ;; check that all rules which are marked mandatory have the corresponding id defined in dict
@@ -69,8 +69,8 @@
                   (if (defined? dict (getf rule 'id))
                      ok?
                      (begin
-                        (write-bytes stderr 
-                           (foldr render '(10) 
+                        (write-bytes stderr
+                           (foldr render '(10)
                               (list "mandatory option not given: " (get rule 'long "(missing)"))))
                         #false))
                   ok?))
@@ -78,11 +78,11 @@
 
       ;; set set all default which are not set explicitly
       (define (fill-defaults dict rules)
-         (fold 
+         (fold
             (λ (dict rule)
                (let ((id (getf rule 'id)))
                   (if (and (undefined? dict id) (defined? rule 'default))
-                     (put dict id 
+                     (put dict id
                         (let ((cookd ((getf rule 'cook) (getf rule 'default))))
                            (if (getf rule 'plural) (list cookd) cookd))) ; <- a single plural default value needs to be listed
                      dict)))
@@ -96,7 +96,7 @@
                (eq? 45 (refb str 0)))))
 
       (define (walk rules args dict others)
-         (cond 
+         (cond
             ((null? args)
                (if (mandatory-args-given? dict rules)
                   (tuple (fill-defaults dict rules) (reverse others))
@@ -117,11 +117,11 @@
                                     ((value (cook (cadr args)))
                                      (ok? ((get rule 'pred self) value)))
                                     (if ok?
-                                       (walk rules 
+                                       (walk rules
                                           ;; instert an implicit -- after terminal rules to stop
                                           (if (getf rule 'terminal) (cons "--" (cddr args)) (cddr args))
                                           (put dict id
-                                             (if (getf rule 'plural) 
+                                             (if (getf rule 'plural)
                                                 ;; put values to a list if this is a multi argument
                                                 (append (get dict id null) (list value))
                                                 value))
@@ -129,7 +129,7 @@
                                        (fail
                                           (list "The argument '" (car args) "' did not accept '" (cadr args) "'.")))))
                               ;; this doesn't have an argument, just count them
-                              (walk rules (cdr args) 
+                              (walk rules (cdr args)
                                  (put dict id (+ 1 (get dict id 0)))
                                  others)))))
                   ((explode (car args)) =>
@@ -190,7 +190,7 @@
          (map
             (λ (lst)
                (if (and (>= (length lst) 3) (symbol? (car lst)))
-                  (cl-rule 
+                  (cl-rule
                      (list->ff (zip cons '(id short long) lst))
                      (cdddr lst))
                   (error "cl-rules: funny option: " lst)))
@@ -204,14 +204,14 @@
       ;; rules → string
       (define (format-rules rules)
          (runes->string
-            (foldr 
-               (λ (rule tl) 
-                  (foldr 
+            (foldr
+               (λ (rule tl)
+                  (foldr
                      render
                      tl
-                     (list "  " 
+                     (list "  "
                         (let ((short (getf rule 'short)))
-                           (if short 
+                           (if short
                               (string-append short " | ")
                               "     "))
                         (getf rule 'long)
@@ -220,7 +220,7 @@
                            (string-append ", " (getf rule 'comment))
                            "")
                         (if (getf rule 'default)
-                           (foldr string-append "]" 
+                           (foldr string-append "]"
                               (list " [" (getf rule 'default)))
                            "")
                         (if (getf rule 'mandatory) " (mandatory)" "")
@@ -229,6 +229,6 @@
                         nl)))
                null rules)))
 
-      (define print-rules 
-         (o display format-rules))
+      (define print-rules
+         (B display format-rules))
 ))

--- a/owl/compile.scm
+++ b/owl/compile.scm
@@ -423,7 +423,7 @@
                (else #false))))
 
       (define null-value? (value-pred null?))
-      (define false-value? (value-pred (c eq? #f)))
+      (define false-value? (value-pred (C eq? #f)))
       (define zero-value? (value-pred zero?))
 
       (define (simple-first a b cont)
@@ -522,7 +522,7 @@
                         ((lambda formals body)
                            (if (opcode-arity-ok? op (length (cdr rands)))
                               (rtl-primitive regs op formals (cdr rands)
-                                 (c rtl-any body))
+                                 (C rtl-any body))
                               ;; fixme: should be a way to show just parts of AST nodes, which may look odd
                               (error "Bad number of arguments for primitive: "
                                  (list 'op (primop-name op) 'got (length (cdr rands)) 'arguments))))

--- a/owl/defmac.scm
+++ b/owl/defmac.scm
@@ -13,7 +13,7 @@
       define-values
       define-record-type
       _record-values
-      not c i o self
+      not B C H I K self
       type-complex
       type-rational
       type-int+
@@ -416,17 +416,19 @@
       (define (not x)
          (if x #false #true))
 
-      (define o (λ (f g) (λ (x) (f (g x)))))
-
-      (define i (λ (x) x))
-
-      (define self i)
-
       ; (define call/cc  ('_sans_cps (λ (k f) (f k (λ (r a) (k a))))))
 
-      (define (c f y) (λ (x) (f x y)))
+      (define (B f g) (λ (x) (f (g x))))
 
-      (define (k x y) x)
+      (define (C f y) (λ (x) (f x y)))
+
+      (define (H f x) (λ (y) (f x y)))
+
+      (define (I x) x)
+
+      (define (K x y) x)
+
+      (define self I)
 
 
       ;;;
@@ -515,7 +517,7 @@
                ;; next must cons accessor of field to tail, so need to lookup its position
                (_record-values find tag mk pred (x ...) fields tail field fields (2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)))
             ((_record-values find tag mk pred left fields tail key (key . rest) (pos . poss))
-               (_record-values emit tag mk pred left fields ((c ref pos) . tail)))
+               (_record-values emit tag mk pred left fields ((C ref pos) . tail)))
             ((_record-values find tag mk pred left fields tail key (x . rest) (pos . poss))
                (_record-values find tag mk pred left fields tail key rest poss))
             ((_record-values find tag mk pred left fields tail key () (pos . poss))

--- a/owl/digest.scm
+++ b/owl/digest.scm
@@ -13,7 +13,7 @@
 ;;; ```
 
 (define-library (owl digest)
-   
+
    (export
       sha1            ;; str | vec | list | ll → str
       sha1-raw        ;; ditto → integer list
@@ -51,7 +51,7 @@
                (c (band (>> n 16) 255))
                (d (band (>> n 24) 255)))
             (values a b c d)))
-                 
+
       (define (sha1-finish-pad bits)
          (cons #x80
             (let loop ((pos (band (+ bits 8) 511)))
@@ -70,7 +70,7 @@
             (bor
                (<< x n)
                (>> x (- 32 n)))))
-      
+
       (define (ror x n)
          (word
             (bor
@@ -97,7 +97,7 @@
             (values (bor (bor d (<< c 8))
                          (bor (<< b 16) (<< a 24)))
                     ll)))
-               
+
       (define (grab-initial-words ll)
          (lets ((a ll (uncons ll #false)))
             (if a ;;something in stream
@@ -177,8 +177,8 @@
                (append (cdr (string->list (number->string (+ #x100 b) 16))) tl))
             null bs)))
 
-   (define sha1-format-result 
-      (o hash-bytes->string ws->bytes))
+   (define sha1-format-result
+      (B hash-bytes->string ws->bytes))
 
       ;; i-3 i-8 i-14 i-16
       (define (sha1-extend-initial-words lst)
@@ -215,10 +215,10 @@
             (else thing))))
 
    (define sha1-bytes
-      (o ws->bytes sha1-raw))
+      (B ws->bytes sha1-raw))
 
-   (define sha1 
-      (o sha1-format-result sha1-raw))
+   (define sha1
+      (B sha1-format-result sha1-raw))
 
    (define (list-xor a b)
       (cond
@@ -239,7 +239,7 @@
          (else
             ;; may be a lazy list or list
             x)))
-      
+
    (define (make-hmac hasher blocksize)
       (lambda (key msg)
          (lets
@@ -255,7 +255,7 @@
             (hasher
                (append (list-xor o-pad key)
                   (hasher (append (list-xor i-pad key) msg)))))))
-               
+
    (define hmac-sha1-bytes
       (make-hmac sha1-bytes sha1-blocksize))
 
@@ -316,7 +316,7 @@
       (let loop ((lst lst) (n 16))
          (if (eq? n 64)
             lst
-            (lets ;;  
+            (lets
                ((p2 l (pick lst 2)) ;; i-2
                 (p7 l (pick l 5))   ;; i-7 
                 (p15 l (pick l 8))  ;; i-15
@@ -325,10 +325,10 @@
                 (s1 (bxor (bxor (ror p2 17) (ror p2 19)) (>> p2 10)))
                 (new (word (+ (+ p16 s0) (+ p7 s1)))))
                (loop (cons new lst) (+ n 1))))))
-               
+
 
    (define (sha256-chunks ll)
-      (let loop 
+      (let loop
          ((ll (sha256-pad ll))
           (h0 #x6a09e667)
           (h1 #xbb67ae85)
@@ -347,7 +347,7 @@
                   (loop ll h0 h1 h2 h3 h4 h5 h6 h7))
                (list h0 h1 h2 h3 h4 h5 h6 h7)))))
 
-   
+
    (define (sha256-raw thing)
       (sha256-chunks
          (cond
@@ -356,10 +356,10 @@
             (else thing))))
 
    (define sha256-bytes
-      (o ws->bytes sha256-raw))
+      (B ws->bytes sha256-raw))
 
    (define sha256
-      (o sha1-format-result sha256-raw))
+      (B sha1-format-result sha256-raw))
 
    (define hmac-sha256-bytes
       (make-hmac sha256-bytes sha256-blocksize))

--- a/owl/dump.scm
+++ b/owl/dump.scm
@@ -5,13 +5,13 @@
 
 (define-library (owl dump)
 
-   (export 
+   (export
       make-compiler    ; ((make-compiler extra-insts) entry path opts native) 
       dump-fasl 
       load-fasl
       suspend)
 
-   (import 
+   (import
       (owl defmac)
       (owl fasl)
       (owl list)
@@ -37,9 +37,9 @@
       (only (owl queue) qnull))
 
    (begin
-      ;;; 
+      ;;;
       ;;; Symbols must be properly interned in a repl.
-      ;;; 
+      ;;;
 
       (define (symbols-of node)
 
@@ -224,9 +224,9 @@
             (cond
                ;; if chosen to be a macro instruction in the new vm, replace with new bytecode calling it
                ;; write a reference to the wrapper function instead of the original bytecode
-               ((get native-ops obj #false) => (c ref 2))
-               ;; if this is a macro instruction in the current system, convert back to vanilla bytecode, or the 
-               ;; target machine won't understand this
+               ((get native-ops obj #false) => (C ref 2))
+               ;; if this is a macro instruction in the current system, convert back
+               ;; to vanilla bytecode, or the target machine won't understand this
                ((extended-opcode obj) =>
                   (λ (opcode)
                      ;(print " * mapping superinstruction back to to bytecode: " opcode)

--- a/owl/fixedpoint.scm
+++ b/owl/fixedpoint.scm
@@ -187,14 +187,14 @@
                                  (list 'call exp 'expects formals)))
                            (mkcall rator
                               (append
-                                 (map (c carry-bindings (env-bind env formals)) rands)
+                                 (map (C carry-bindings (env-bind env formals)) rands)
                                  (map mkvar deps))))
                         (else
                            (mkcall (carry-bindings rator env)
-                              (map (c carry-bindings env) rands)))))
+                              (map (C carry-bindings env) rands)))))
                   (else
                      (mkcall (carry-bindings rator env)
-                        (map (c carry-bindings env) rands)))))
+                        (map (C carry-bindings env) rands)))))
             ((lambda formals body)
                (mklambda formals
                   (carry-bindings body
@@ -224,7 +224,7 @@
             ((value val) exp)
             ((values vals)
                (tuple 'values
-                  (map (c carry-bindings env) vals)))
+                  (map (C carry-bindings env) vals)))
             (else
                (error "carry-bindings: strage expression: " exp))))
 
@@ -391,7 +391,7 @@
 
       (define (unletrec exp env)
          (define (unletrec-list exps)
-            (map (c unletrec env) exps))
+            (map (C unletrec env) exps))
          (tuple-case exp
             ((var value) exp)
             ((call rator rands)
@@ -407,7 +407,7 @@
             ((rlambda names values body)
                (lets
                   ((env (env-bind env names))
-                   (handle (c unletrec env)))
+                   (handle (C unletrec env)))
                   (compile-rlambda names (map handle values) (handle body) env)))
             ((receive op fn)
                (tuple 'receive (unletrec op env) (unletrec fn env)))

--- a/owl/list-extra.scm
+++ b/owl/list-extra.scm
@@ -1,6 +1,6 @@
 (define-library (owl list-extra)
 
-   (export 
+   (export
       lref lset ldel length
       led ledn lins
       take drop iota
@@ -68,11 +68,11 @@
                (lets ((hd tl lst))
                   (cons hd (lins tl (- pos 1) val))))))
 
-      (example         
+      (example
          (lref '(a b c) 1) = 'b
          (lset '(a b c) 1 'x) = '(a x c)
          (ldel '(a b c) 1)  = '(a c)
-         (led '(1 2 3) 1 (c * 10)) =  '(1 20 3)
+         (led '(1 2 3) 1 (C * 10)) =  '(1 20 3)
          (ledn '(1 2 3) 1 (λ (lst) (cons 'x lst))) = '(1 x 2 3)
          (lins '(a b c) 1 'x) = '(a x b c))
 
@@ -116,9 +116,9 @@
                (if (< to from) null (iota-up from step to)))
             ((< step 0)
                (if (> to from) null (iota-down from step to)))
-            ((= from to) 
+            ((= from to)
                null)
-            (else 
+            (else
                (error "bad iota: " (list 'iota from step to)))))
 
       (example
@@ -136,14 +136,14 @@
                out
                (loop (- n 1) (cons thing out)))))
 
-      (define (split l n)  
+      (define (split l n)
          (let loop ((l l) (o null) (n n))
             (cond
                ((null? l)
                   (values (reverse o) l))
                ((eq? n 0)
                   (values (reverse o) l))
-               (else 
+               (else
                   (loop (cdr l) (cons (car l) o) (- n 1))))))
 
       (example

--- a/owl/list.scm
+++ b/owl/list.scm
@@ -1,14 +1,14 @@
 (define-library (owl list)
 
-   (export 
+   (export
       null pair? null?
       caar cadr cdar cddr
-      list?      
+      list?
       zip fold foldr map for-each
       has? getq last drop-while
       mem
       fold-map foldr-map
-      append reverse keep remove 
+      append reverse keep remove
       all some
       smap unfold
       take-while                ;; pred, lst -> as, bs
@@ -18,7 +18,7 @@
       edit                      ;; op lst → lst'
       interleave
       ╯°□°╯
-      
+
       diff union intersect)
 
    (import
@@ -69,19 +69,19 @@
             (else
                (let ((hd (op (car a) (car b))))
                   (cons hd (zip op (cdr a) (cdr b)))))))
-      
+
       ;; op state lst -> state', walk over a list from left and compute a value
-      
-      (define (fold op state lst) 
-         (if (null? lst) 
-            state 
-            (fold op 
+
+      (define (fold op state lst)
+         (if (null? lst)
+            state
+            (fold op
                (op state (car lst))
                (cdr lst))))
 
-      (example 
+      (example
          (zip cons '(1 2 3) '(a b c d)) = '((1 . a) (2 . b) (3 . c)))
-      
+
       (define (unfold op st end?)
          (if (end? st)
             null
@@ -102,21 +102,21 @@
             st
             (op (car lst)
                (foldr op st (cdr lst)))))
-      
+
       (example (foldr cons null '(a b c)) = '(a b c))
 
       ;; fn lst -> lst', run a function to all elements of a list
       (define (map fn lst)
          (if (null? lst)
             null
-            (lets 
+            (lets
                ((hd tl lst)
                 (hd (fn hd))) ;; compute head first
                (cons hd (map fn tl)))))
 
       (example
          (map not '(#false #false #true)) = '(#true #true #false))
-      
+
       ;; fn lst -> _, run a function to all elements of a list for side effects
       (define (for-each op lst)
          (if (null? lst)
@@ -138,20 +138,20 @@
             ((null? lst) #false)
             ((eq? k (car (car lst))) (car lst))
             (else (getq (cdr lst) k))))
-      
-      (example 
+
+      (example
          (getq '((a . 1) (b . 2)) 'a) = '(a . 1)
          (getq '((a . 1) (b . 2)) 'c) = #false)
-         
+
 
       ;; last list default -> last-elem | default, get the last value of a list
       (define (last l def)
-         (fold (λ (a b) b) def l)) 
+         (fold (λ (a b) b) def l))
 
       (example
          (last '(1 2 3) 'a) = 3
          (last '() 'a) = 'a)
-      
+
       ;; mem compare lst elem -> bool, check if lst contains elem comparing with compare
       (define (mem cmp lst elem)
          (cond
@@ -163,7 +163,7 @@
          (if (null? a)
             b
             (cons (car a) (app (cdr a) b app))))
-      
+
       (define (appl l appl)
          (if (null? (cdr l))
             (car l)
@@ -172,7 +172,7 @@
       ;; append list ... -> list', join lists
       ;;    (append '(1) '() '(2 3)) = '(1 2 3)
       (define append
-         (case-lambda 
+         (case-lambda
             ((a b) (app a b app))
             ((a b . cs) (app a (app b (appl cs appl) app) app))
             ((a) a)
@@ -181,7 +181,7 @@
 
       (example
          (append '(1 2 3) '(a b c)) = '(1 2 3 a b c))
-      
+
       ; todo: update to work like ledit
       (define (edit op l)
          (if (null? l)
@@ -199,11 +199,11 @@
             (rev-loop (cdr a) (cons (car a) b))))
 
       ;; lst -> lst', reverse a list
-      (define (reverse l) (rev-loop l null))   
+      (define (reverse l) (rev-loop l null))
 
-      (example 
+      (example
          (reverse '(1 2 3)) = '(3 2 1))
-      
+
       ;; misc
 
       (define (drop-while pred lst)
@@ -224,7 +224,7 @@
          (foldr (λ (x tl) (if (pred x) (cons x tl) tl)) null lst))
 
       (define (remove pred lst)
-         (keep (o not pred) lst))
+         (keep (B not pred) lst))
 
       (let ((l '(1 2 () 3 () 4)))
          (example
@@ -235,7 +235,7 @@
          (withcc ret
             (fold (λ (ok x) (if (pred x) ok (ret #false))) #true lst)))
 
-      (define (some pred lst) 
+      (define (some pred lst)
          (withcc ret
             (fold (λ (_ x) (let ((v (pred x))) (if v (ret v) #false))) #false lst)))
 
@@ -243,7 +243,7 @@
          (example
             (some null? l) = #true
             (all null? l) = #false))
-      
+
       ; map carrying one state variable down like fold
       (define (smap op st lst)
          (if (null? lst)
@@ -262,7 +262,7 @@
       (example
          (first null? '(1 2 3) 42) = 42
          (first null? '(1 ()) 42) = ())
-      
+
       (define (fold-map o s l)
          (let loop ((s s) (l l) (r null))
             (if (null? l)
@@ -311,7 +311,7 @@
             (union abc def) = '(a b c d e f)
             (intersect abc cd) = '(c)
             (diff abc cd) = (diff abc (intersect abc cd))))
-         
+
       (define (interleave mid lst)
          (if (null? lst)
             null
@@ -319,7 +319,7 @@
                (if (null? as)
                   (list a)
                   (ilist a mid (loop (car as) (cdr as)))))))
-      
+
       ;; lst → a b, a ++ b == lst, length a = length b | length b + 1
       (define (halve lst)
          (let walk ((t lst) (h lst) (out null))
@@ -330,14 +330,14 @@
                      (values (reverse (cons (car t) out)) (cdr t))
                      (walk (cdr t) (cdr h) (cons (car t) out)))))))
       (lets ((l '(a b c d e f)))
-         (example 
+         (example
             l = (lets ((head tail (halve l))) (append head tail))))
-            
+
       (example
          (interleave 'x '(a b c)) = '(a x b x c)
          (interleave 'x '()) = ()
          (halve '(a b c d)) = (values '(a b) '(c d))
          (halve '(a b c d e)) = (values '(a b c) '(d e)))
 
-      (define ╯°□°╯ reverse)     
+      (define ╯°□°╯ reverse)
 ))

--- a/owl/macro.scm
+++ b/owl/macro.scm
@@ -38,7 +38,7 @@
                   (cons exp found))
                (else found)))
 
-         (c walk null))
+         (C walk null))
 
 
       ;;;
@@ -169,7 +169,7 @@
       ;; single matches can be used along with ellipsis matches.
 
       (define (repetition-length dict)
-         (let loop ((opts (sort < (map (o length cdr) dict))) (best 0))
+         (let loop ((opts (sort < (map (B length cdr) dict))) (best 0))
             (cond
                ((null? opts)
                   ;; 0 if ellipsis with empty match, or 1 due to ellipsis of lenght 1 or just normal valid bindings

--- a/owl/math.scm
+++ b/owl/math.scm
@@ -266,7 +266,7 @@
             (else (error 'negative? a))))
 
       (define positive?
-         (o not negative?))
+         (B not negative?))
 
       ;; RnRS compat
       (define real? number?)
@@ -1251,7 +1251,7 @@
                    (bp (rmul-digit b f))
                    (ap (rev-sub a bp)))
                   (if ap (rrem ap b) a)))
-            ((rev-sub a b) => (c rrem b))
+            ((rev-sub a b) => (C rrem b))
             (else
                (lets
                   ((h o (fx+ (ncar b) 1))

--- a/owl/ol.scm
+++ b/owl/ol.scm
@@ -2,24 +2,24 @@
 ;;; ol.scm: an Owl read-eval-print loop.
 ;;;
 
-#| Copyright (c) 2012-2017 Aki Helin
+#| Copyright (c) 2012-2018 Aki Helin
  |
- | Permission is hereby granted, free of charge, to any person obtaining a 
+ | Permission is hereby granted, free of charge, to any person obtaining a
  | copy of this software and associated documentation files (the "Software"),
  | to deal in the Software without restriction, including without limitation
  | the rights to use, copy, modify, merge, publish, distribute, sublicense,
  | and/or sell copies of the Software, and to permit persons to whom the
  | Software is furnished to do so, subject to the following conditions
  |
- | The above copyright notice and this permission notice shall be included 
+ | The above copyright notice and this permission notice shall be included
  | in all copies or substantial portions of the Software.
  |
  | THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  | IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- | FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ | FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
  | THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- | LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- | FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ | LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ | FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  | DEALINGS IN THE SOFTWARE.
  |#
 
@@ -131,7 +131,7 @@
       tuple? string? function? procedure? equal? eqv? bytecode?
       not
       null? null
-      o
+      B
       time
       time-ms
       halt
@@ -376,7 +376,7 @@ Check out https://github.com/aoh/owl-lisp for more information.")
                      (print "Owl Lisp " *owl-version*)
                      0)
                   ((getf dict 'about) (print about-owl) 0)
-                  ((getf dict 'load) => (c try-load-state others))
+                  ((getf dict 'load) => (C try-load-state others))
                   ((or (getf dict 'output) (getf dict 'output-format))
                      (if (< (length others) 2) ;; can take just one file or stdin
                         (repl-compile compiler env

--- a/owl/parse.scm
+++ b/owl/parse.scm
@@ -11,7 +11,7 @@
       byte
       imm
       seq
-      epsilon ε 
+      epsilon ε
       byte-if
       rune
       either
@@ -45,7 +45,7 @@
       (owl io)
       (owl syscall))
 
-   (begin 
+   (begin
 
       ; (parser l r ok) → (ok l' r' val) | (backtrack l r why)
       ;   ... → l|#f r result|error
@@ -69,13 +69,13 @@
       (define (imm x)
          (λ (l r ok)
             (cond
-               ((null? r) 
+               ((null? r)
                   (backtrack l r eof-error))
-               ((pair? r) 
+               ((pair? r)
                   (if (eq? (car r) x)
                      (ok (cons (car r) l) (cdr r) x)
                      (backtrack l r 'bad-byte)))
-               (else 
+               (else
                   ((imm x) l (r) ok)))))
 
       (define (ε val)
@@ -92,16 +92,16 @@
          (λ (l r ok)
             (a l r
                (λ (l r av)
-                  (b l r 
+                  (b l r
                      (λ (l r bv)
                         (ok l r (cons av bv))))))))
 
       (define (star-vals a vals)
          (λ (l r ok)
-            (a 
-               (cons 
+            (a
+               (cons
                   (λ (l r why) (ok l r (reverse vals))) l)
-                r 
+                r
                 (λ (l r val)
                    ((star-vals a (cons val vals)) l r ok)))))
 
@@ -132,7 +132,7 @@
                (parser l r
                   (λ (l r val)
                      (let-parses 42 l r ok rest body))))
-            ((let-parses 42 l r ok () body) 
+            ((let-parses 42 l r ok () body)
                (ok l r body))
             ((let-parses 42 l r ok ((verify term msg) . rest) body)
                (if term
@@ -187,7 +187,7 @@
             a))
 
       ; #b10xxxxxx
-      (define extension-byte 
+      (define extension-byte
          (let-parses
             ((b byte)
              (verify (eq? #b10000000 (fxband b #b11000000)) "Bad extension byte"))
@@ -201,7 +201,7 @@
 
       (define rune
          (any
-            (byte-if (c lesser? 128))
+            (byte-if (C lesser? 128))
             (let-parses
                ((a (byte-between 127 224))
                 (verify (not (eq? a #b11000000)) "blank leading 2-byte char") ;; would be non-minimal
@@ -237,7 +237,7 @@
       (define (fd->exp-stream fd parser fail)
          (let loop ((ll (port->byte-stream fd)))
             (lets
-               ((lp r val 
+               ((lp r val
                    (parser null ll parser-succ)))
                (cond
                   (lp ;; something parsed successfully
@@ -272,7 +272,7 @@
       (define get-either either)
       (define get-word word)
 
-      (define (try-parse parser data maybe-path maybe-error-msg fail-fn) 
+      (define (try-parse parser data maybe-path maybe-error-msg fail-fn)
          (lets ((l r val (parser null data parser-succ)))
             (cond
                ((not l)

--- a/owl/random.scm
+++ b/owl/random.scm
@@ -31,7 +31,7 @@
 
 (define-library (owl random)
 
-   (export   
+   (export
       ;; prngs
       lcg-rands           ;; seed (int32) → rands
 
@@ -116,7 +116,7 @@
                (nrev-iter ds (ncons d to)))))
 
       (define (nrev-fix ds)
-         (if (null? ds) 
+         (if (null? ds)
             0
             (lets ((d ds ds))
                (cond
@@ -130,16 +130,16 @@
       (define word32 #xffffffff)
 
       (define (xorshift-128 x y z w)
-         (lets 
+         (lets
             ((t (bxor x (band word32 (<< x 11))))
              (x y)
              (y z)
              (z w)
              (w (bxor w (bxor (>> w 19) (bxor t (>> t 8))))))
             (if (eq? (type w) type-fix+)
-               (cons w (cons 0 
+               (cons w (cons 0
                   (λ () (xorshift-128 x y z w))))
-               (cons (ncar w) (cons (ncar (ncdr w)) 
+               (cons (ncar w) (cons (ncar (ncdr w))
                   (λ () (xorshift-128 x y z w)))))))
 
       (define xors (xorshift-128 123456789 362436069 521288629 88675123))
@@ -194,7 +194,7 @@
          (if (eq? 0 (fxband x n)) 0 1))
 
       (define (rands->bits rs)
-         (lets 
+         (lets
             ((d rs (uncons rs 0))
              (tl (λ () (rands->bits rs))))
             (let loop ((p #b1000000000000000))
@@ -204,23 +204,23 @@
 
       ;; assumes 24-bit fixnums
       (define (rands->bytes rs)
-         (lets 
+         (lets
             ((digit rs (uncons rs 0))
              (lo (fxband digit #xff))
              (digit _ (fx>> digit 8))
              (mid (fxband digit #xff))
              (hi _ (fx>> digit 8)))
-            (ilist lo mid hi 
+            (ilist lo mid hi
                (λ () (rands->bytes rs)))))
 
       ;; passed dieharder tests surprisingly well
       (define seed->rands adhoc-seed->rands)
 
-      (define seed->bits 
-         (o rands->bits seed->rands))
+      (define seed->bits
+         (B rands->bits seed->rands))
 
       (define seed->bytes
-         (o rands->bytes seed->rands))
+         (B rands->bytes seed->rands))
 
       ;; note, a custom uncons could also promote random seeds to streams, but probably better to force 
       ;; being explicit about the choice of prng and require all functions to receive just digit streams.
@@ -234,7 +234,7 @@
       (define (rand-big rs n)
          (if (null? n)
             (values rs null #true)
-            (lets 
+            (lets
                ((rs head eq (rand-big rs (ncdr n)))
                 (this rs (uncons rs 0)))
                (if eq
@@ -293,7 +293,7 @@
                (else (error "bad rand limit: " max)))))
 
       ;; a quick skew check. definite doom if delta percent > 0, but please do dieharder later.
-      '(let 
+      '(let
          ((lim #b11111111111111111111111111))
          ;((lim #b10000000000000000000000000))
          ;((lim #b1000000000000000000000000))
@@ -304,7 +304,7 @@
             (if (eq? 0 (band 1023 n))
                (let ((avg (div sum (max n 1))))
                   (print
-                     (list "at " n " sum " sum " avg " avg " delta percent " 
+                     (list "at " n " sum " sum " avg " avg " delta percent "
                         (let ((perc (div (* 100 (abs (- (>> lim 1) avg))) (>> lim 1))))
                            perc)))))
             (lets ((rs val (rand rs lim)))
@@ -334,7 +334,7 @@
          (cond
             ((null? lst) out)
             ((eq? this (band bits this))
-               (select-members lst (- bits this) this 
+               (select-members lst (- bits this) this
                   (cons (car lst) out)))
             ((eq? this #x8000) ; highest fixnum bit
                (select-members (cdr lst) (ncdr bits) 1 out))
@@ -373,19 +373,19 @@
             ((null? ll)
                (values rs (return-selection res)))
             ((pair? ll)
-               (lets 
+               (lets
                   ((rs x (rand rs p))
                    (res (if (< x n) (rset res x (car ll)) res)))
                   (reservoir-sampler rs (cdr ll) n (+ p 1) res)))
-            (else 
+            (else
                (reservoir-sampler rs (ll) n p res))))
 
       ;; populate initial n elements to reservoir and start sampler if full
       (define (reservoir-init rs ll n p res)
          (cond
-            ((null? ll) 
+            ((null? ll)
                (values rs (return-selection res)))
-            ((= n p) 
+            ((= n p)
                (reservoir-sampler rs ll n (+ n 1) res))
             ((pair? ll) (reservoir-init rs (cdr ll) n (+ p 1) (rcons (car ll) res)))
             (else (reservoir-init rs (ll) n p res))))
@@ -416,7 +416,7 @@
                (values rs n))))
 
       (define (rand-range rs lo hi)
-         (if (< lo hi) 
+         (if (< lo hi)
             ;; fixme: is this indeed ok?
             (lets ((rs o (rand rs (- hi lo))))
                (values rs (+ o lo)))
@@ -455,7 +455,7 @@
 
       (define (shuffler rs lst tail)
          (if (null? lst)
-            (values rs tail) 
+            (values rs tail)
             (lets
                ((rs opts (fold2 shuffle-label rs null lst))
                 (opts (sort carless opts)))
@@ -482,11 +482,11 @@
                (values rs (raw (reverse out) type-vector-raw)) ; reverses to keep order
                (lets
                   ((d rs (uncons rs 0))
-                   (n _ (fx- n 1))) 
+                   (n _ (fx- n 1)))
                   (loop rs (cons (fxband d 255) out) n)))))
 
       (define (random-data-file rs path)
-         (let 
+         (let
             ((port (open-output-file path))
              (block (* 1024 32)) ; write in 32kb blocks
              (megs (* 1024 500))) ; ~1GB is enough for dieharder and smallcrush, 500 might be enough for crush?
@@ -528,7 +528,7 @@
       ;;;
 
       (define (prng-speed str)
-         (let 
+         (let
             ((start (time-ms))
              (ndigits (* 1024 64))) ; make 1mb 
             (let loop ((str str) (n ndigits))

--- a/owl/regex.scm
+++ b/owl/regex.scm
@@ -572,7 +572,7 @@
                ((string? target)
                   (let ((res (rex-full-match (str-iter target) rex)))
                      (if res
-                        (map (o runes->string cdr)
+                        (map (B runes->string cdr)
                            (cdr (reverse res)))
                         #false)))
                (else
@@ -887,13 +887,13 @@
                   get-plus
                   get-quest
                   get-range
-                  (get-epsilon i)))
+                  (get-epsilon self)))
              (tail
                (any
                   (let-parses ;; join tail of exp with implicit catenation
                      ((tl (get-catn get-regex)))
-                     (c rex-and tl))
-                  (get-epsilon i)))) ;; nothing
+                     (C rex-and tl))
+                  (get-epsilon self)))) ;; nothing
            (tail (repetition regex))))
 
       ;; get a sequence of regexps with zero or more | in between and merge them

--- a/owl/register.scm
+++ b/owl/register.scm
@@ -9,8 +9,8 @@
 
 (define-library (owl register)
 
-   (export 
-      allocate-registers 
+   (export
+      allocate-registers
       n-registers)
 
    (import
@@ -28,7 +28,7 @@
    (begin
       ;; fixme: temp register limit
       (define highest-register 95) ;; atm lower than NR in ovm.c
-      (define n-registers (+ highest-register 1)) 
+      (define n-registers (+ highest-register 1))
 
       ; reg-touch U r -> mark as live -> make sure it has a value 
       ; (must be in some register)
@@ -47,7 +47,7 @@
       ; return a list of registers from uses (where the value has been moved to), or 
       ; some list of low registers if this one is outside the available ones
       (define (use-list uses reg)
-         (let ((opts (keep (c < highest-register) (get uses reg null))))
+         (let ((opts (keep (C < highest-register) (get uses reg null))))
             (cond
                ((< reg highest-register)
                   opts)
@@ -93,7 +93,7 @@
                            (tuple 'move a b (rtl-rename more op target fail)))))))
             ((prim opcode args to more)
                (if (fixnum? to)
-                  (if (bad? to target op) 
+                  (if (bad? to target op)
                      (fail)
                      (tuple 'prim opcode
                         (map op args)
@@ -102,7 +102,7 @@
                      (fail)
                      (tuple 'prim opcode (map op args) to (rtl-rename more op target fail)))))
             ((clos-proc lp off env to more)
-               (if (bad? to target op) 
+               (if (bad? to target op)
                   (fail)
                   (tuple 'clos-proc (op lp) off (map op env) to (rtl-rename more op target fail))))
             ((clos-code lp off env to more)
@@ -146,10 +146,10 @@
             (let ((new (car news)))
                (if (or (eq? old new) (get uses new #false))
                   (retarget-first code old (cdr news) uses cont)
-                  (let ((new-code 
+                  (let ((new-code
                      (call/cc
                         (λ (drop)
-                           (rtl-rename code 
+                           (rtl-rename code
                               (λ (reg) (if (eq? reg old) new reg))
                               new
                               (lambda () (drop #false)))))))
@@ -158,7 +158,7 @@
                         (retarget-first code old (cdr news) uses cont)))))))
 
       (define (rtl-retard-jump proc op a b then else)
-         (lets 
+         (lets
             ((then then-uses (proc then))
              (else else-uses (proc else))
              (uses (merge-usages then-uses else-uses))
@@ -203,7 +203,7 @@
                   ((> b highest-register)
                      (error "out of registers in move: " b))
                   (else
-                     (lets 
+                     (lets
                         ((more uses (rtl-retard more))
                          (uses (del uses b))
                          (targets (use-list uses a)))
@@ -214,9 +214,9 @@
                            (values (tuple 'move a b more) (put uses a (cons b targets))))))))
 
             ((prim op args to more)
-               (lets 
+               (lets
                   ((more uses (rtl-retard more))
-                   (pass 
+                   (pass
                      (λ () (values
                         (tuple 'prim op args to more)
                         (fold reg-touch (del uses to) args)))))
@@ -250,7 +250,7 @@
                         (pass)))))
 
             ((ld val to cont)
-               (lets 
+               (lets
                   ((cont uses (rtl-retard cont))
                    (good (use-list uses to))
                    (good (if (> to highest-register) (append good (iota 0 1 highest-register)) good))
@@ -261,19 +261,19 @@
                            (pass)
                            (rtl-retard (tuple 'ld val to-new cont-new)))))))
 
-            ((clos-proc lpos offset env to more)  
+            ((clos-proc lpos offset env to more)
                (rtl-retard-closure rtl-retard code))
 
-            ((clos-code lpos offset env to more) 
+            ((clos-code lpos offset env to more)
                (rtl-retard-closure rtl-retard code))
 
             ((refi from offset to more)
-               (lets 
+               (lets
                   ((more uses (rtl-retard more))
                    (uses (reg-touch uses from))
                    (good (use-list uses to))
-                   (uses (del uses to)) 
-                   (pass 
+                   (uses (del uses to))
+                   (pass
                      (λ () (values (tuple 'refi from offset to more)
                         (reg-touch uses from)))))
                   (retarget-first more to good uses

--- a/owl/string.scm
+++ b/owl/string.scm
@@ -81,7 +81,7 @@
       ;;; enumerate code points forwards
 
       (define (str-iter-leaf str tl pos end)
-         (if (eq? pos end) 
+         (if (eq? pos end)
             tl
             (pair (refb str pos)
                (lets ((pos u (fx+ pos 1)))
@@ -101,7 +101,7 @@
                   (if (eq? len 0)
                      tl
                      (str-iter-leaf str tl 0 len))))
-            (type-string-wide 
+            (type-string-wide
                (str-iter-wide-leaf str tl 1))
             (type-string-dispatch
                (let loop ((pos 2))
@@ -160,7 +160,7 @@
 
       (define (hexencode cp tl)
          (ilist #\\ #\x
-            (append (render-number cp null 16) 
+            (append (render-number cp null 16)
                (cons #\; tl))))
 
       (define (maybe-hexencode char tl)
@@ -169,7 +169,7 @@
                (hexencode char tl))
             ((eq? char 128)
                (hexencode char tl))
-            (else 
+            (else
                #false)))
 
       ;; quote just ":s for now
@@ -193,7 +193,7 @@
       (define (string->bytes str)    (str-foldr encode-point null str))
       (define (render-string str tl) (str-foldr encode-point tl str))
       (define (string->runes str)    (str-foldr cons null str))
-      (define (render-quoted-string str tl) 
+      (define (render-quoted-string str tl)
          (str-foldr encode-quoted-point tl str))
 
 
@@ -237,7 +237,7 @@
       (define (stringify runes out n ascii? chu)
          (cond
             ((null? runes)
-               (finish-string 
+               (finish-string
                   (reverse (cons (make-chunk out n ascii?) chu))))
             ; make 4Kb chunks by default
             ((eq? n 4096)
@@ -246,23 +246,23 @@
             ((pair? runes)
                (cond
                   ((and ascii? (< 128 (car runes)) (> n 256))
-                     ; allow smaller leaf chunks 
+                     ; allow smaller leaf chunks
                      (stringify runes null 0 #true
                         (cons (make-chunk out n ascii?) chu)))
                   ((valid-code-point? (car runes))
                      (let ((rune (car runes)))
-                        (stringify (cdr runes) (cons rune out) (+ n 1) 
+                        (stringify (cdr runes) (cons rune out) (+ n 1)
                            (and ascii? (< rune 128))
                            chu)))
                   (else #false)))
             (else (stringify (runes) out n ascii? chu))))
 
       ;; (codepoint ..) → string | #false
-      (define (runes->string lst) 
+      (define (runes->string lst)
          (stringify lst null 0 #true null))
 
-      (define bytes->string 
-         (o runes->string utf8-decode))
+      (define bytes->string
+         (B runes->string utf8-decode))
 
       ;;; temps
 
@@ -270,14 +270,14 @@
       ; figure out how to handle balancing. 234-trees with occasional rebalance?
       (define (str-app a b)
          (bytes->string
-            (render-string a 
+            (render-string a
                (render-string b null))))
 
       (define (string-eq-walk a b)
          (cond
             ((pair? a)
                (cond
-                  ((pair? b) 
+                  ((pair? b)
                      (if (= (car a) (car b))
                         (string-eq-walk (cdr a) (cdr b))
                         #false))
@@ -287,7 +287,7 @@
                         (if (and (pair? b) (= (car b) (car a)))
                            (string-eq-walk (cdr a) (cdr b))
                            #false)))))
-            ((null? a) 
+            ((null? a)
                (cond
                   ((pair? b) #false)
                   ((null? b) #true)
@@ -372,7 +372,7 @@
          (runes->string
             (str-iterr str)))
 
-      (define string-copy i)
+      (define string-copy self)
 
       ;; going as per R5RS
       (define (substring str start end)
@@ -383,14 +383,14 @@
                (error "substring: negative start: " start))
             ((< end start)
                (error "substring: bad interval " (cons start end)))
-            (else 
+            (else
                (list->string (ltake (ldrop (str-iter str) start) (- end start))))))
 
       ;; lexicographic comparison with end of string < lowest code point
       ;; 1 = sa smaller, 2 = equal, 3 = sb smaller
       (define (str-compare cook sa sb)
          (let loop ((la (cook (str-iter sa))) (lb (cook (str-iter sb))))
-            (lets 
+            (lets
                ((a la (uncons la #false))
                 (b lb (uncons lb #false)))
                (cond
@@ -402,10 +402,10 @@
 
       ;; iff of codepoint → codepoint | (codepoint ...), the first being equal to (codepoint)
       (define char-fold-iff
-         (fold 
-            (λ (iff node) 
-               (if (= (length node) 2) 
-                  (iput iff (car node) (cadr node)) 
+         (fold
+            (λ (iff node)
+               (if (= (length node) 2)
+                  (iput iff (car node) (cadr node))
                   (iput iff (car node) (cdr node))))
             #empty char-folds))
 
@@ -421,7 +421,7 @@
          (llref (str-iter str) p))
 
       (define (upcase ll)
-         (lets 
+         (lets
             ((cp ll (uncons ll #false)))
             (if cp
                (let ((cp (iget char-fold-iff cp cp)))
@@ -434,7 +434,7 @@
 
       ;; fixme: incomplete, added because needed for ascii range elsewhere
       (define (char-ci=? a b)
-         (or (eq? a b) 
+         (or (eq? a b)
             (=
                (iget char-fold-iff a a)
                (iget char-fold-iff b b))))
@@ -442,10 +442,10 @@
       (define string=? string-eq?)
       (define (string-ci=? a b) (eq? 2 (str-compare upcase a b)))
 
-      (define (string<? a b)       (eq? 1 (str-compare i a b)))
-      (define (string<=? a b) (not (eq? 3 (str-compare i a b))))
-      (define (string>? a b)       (eq? 3 (str-compare i a b)))
-      (define (string>=? a b) (not (eq? 1 (str-compare i a b))))
+      (define (string<? a b)       (eq? (str-compare self a b) 1))
+      (define (string<=? a b) (not (eq? (str-compare self a b) 3)))
+      (define (string>? a b)       (eq? (str-compare self a b) 3))
+      (define (string>=? a b) (not (eq? (str-compare self a b) 1)))
 
       (define (string-ci<? a b)       (eq? 1 (str-compare upcase a b)))
       (define (string-ci<=? a b) (not (eq? 3 (str-compare upcase a b))))
@@ -453,7 +453,7 @@
       (define (string-ci>=? a b) (not (eq? 1 (str-compare upcase a b))))
 
       (define (str-iter-bytes str)
-         (ledit 
+         (ledit
             (lambda (codepoint tl)
                (if (lesser? codepoint #x80)
                   (cons codepoint tl)

--- a/owl/thread.scm
+++ b/owl/thread.scm
@@ -10,9 +10,9 @@
 
 (define-library (owl thread)
 
-   (export 
+   (export
       start-thread-controller
-      thread-controller 
+      thread-controller
       repl-signal-handler
       try)
 
@@ -52,7 +52,7 @@
                   ;(values state #false)
                   )
                (else ;; activate the state function
-                  (values 
+                  (values
                      (fupd state to qnull) ;; leave an inbox
                      (tuple to (λ () (st envelope)))))))) ;; activate it
 
@@ -78,7 +78,7 @@
                   ;; no threads were waiting for something that is being removed, so tell stderr about it
                   ;(print*-to stderr "VM: thread " id " exited")
                   (tc tc todo done (del state id)))
-               (deliver-messages todo done 
+               (deliver-messages todo done
                   (del (fupd state link-tag (del (get state link-tag empty) id)) id)
                   subs msg tc))))
 
@@ -87,20 +87,20 @@
          (cond
             ((null? lst) lst)
             ((eq? (ref (car lst) 1) tid) (cdr lst))
-            (else 
-               (cons (car lst) 
+            (else
+               (cons (car lst)
                   (drop-from-list (cdr lst) tid)))))
 
       ; drop a possibly running thread and notify linked 
       (define (drop-thread id todo done state msg tc) ; -> todo' x done' x state'
-         (drop-delivering 
+         (drop-delivering
             (drop-from-list todo id)
             (drop-from-list done id)
             state id msg tc))
 
       ; l id → #false|thread l', O(n) running threads
       (define (catch-thread l id)
-         (if (null? l) 
+         (if (null? l)
             (values #false l)
             (let ((this (car l)))
                (if (eq? id (ref this 1))
@@ -124,7 +124,7 @@
             ; 2, thread finished, drop
             (λ (id a b c todo done state tc)
                ; (system-println "mcp: syscall 2 -- thread finished")
-               (drop-delivering todo done state id 
+               (drop-delivering todo done state id
                   (tuple id (tuple 'finished a b c)) tc))
 
             ; 3, vm thrown error
@@ -132,16 +132,16 @@
                ;(system-println "mcp: syscall 3 -- vm error")
                ;; set crashed exit value proposal 
                (let ((state (put state return-value-tag 126)))
-                  (drop-delivering todo done state id 
+                  (drop-delivering todo done state id
                      (tuple id (tuple 'crashed a b c)) tc)))
 
             ; 4, fork
             (λ (id cont opts thunk todo done state tc)
-               (lets 
+               (lets
                   ((new-id (car opts))
                    (todo (ilist (tuple new-id thunk) (tuple id (λ () (cont new-id))) todo))
                    (state
-                      (fold 
+                      (fold
                         (λ (state req)
                            (cond
                               ((eq? req 'link)
@@ -161,7 +161,7 @@
             ; 5, user thrown error
             (λ (id a b c todo done state tc)
                ; (system-println "mcp: syscall 5 -- user poof")
-               (drop-delivering todo done state id 
+               (drop-delivering todo done state id
                   (tuple id (tuple 'error a b c)) tc))
 
             ;; return mails to my own inbox (in reverse order, newest on top)
@@ -174,19 +174,19 @@
 
             ; 7, am i the only thread?
             (λ (id cont b c todo done state tc)
-               (tc tc 
+               (tc tc
                   (cons (tuple id (λ () (cont (and (null? todo) (null? done))))) todo)
                   done state))
 
             ; 8, get running thread ids (sans self)
             (λ (id cont b c todo done state tc)
-               (let 
+               (let
                   ((ids
                      (append
-                        (map (c ref 1) todo)
-                        (map (c ref 1) done))))
-                  (tc tc 
-                     (cons 
+                        (map (C ref 1) todo)
+                        (map (C ref 1) done))))
+                  (tc tc
+                     (cons
                         (tuple id (λ () (cont ids)))
                         todo)
                      done state)))
@@ -216,7 +216,7 @@
 
             ; 12, set break action
             (λ (id cont choice x todo done state tc)
-               (tc tc  
+               (tc tc
                   (cons (tuple id (λ () (cont #true))) todo)
                   done (put state signal-tag choice)))
 
@@ -237,7 +237,7 @@
             (λ (id a b c todo done state tc)
                (system-println "syscall 14 - memlimit exceeded, dropping a thread")
                ; for now, kill the currently active thread (a bit dangerous) 
-               (drop-delivering todo done state id 
+               (drop-delivering todo done state id
                   (tuple id (tuple 'crashed 'memory-limit b c)) tc))
 
             ; 15, drop local thread
@@ -282,16 +282,16 @@
             ;;; 20 & 21 change during profiling 
 
             ; 20, start profiling, no-op during profiling returning 'already-profiling
-            (λ (id cont b c todo done state tc) 
+            (λ (id cont b c todo done state tc)
                (tc tc (cons (tuple id (λ () (cont 'already-profiling))) todo) done state))
 
             ; 21, end profiling, resume old ones, pass profiling info 
-            (λ (id cont b c todo done state tc) 
+            (λ (id cont b c todo done state tc)
                (lets
                   ((prof (get state 'prof #false)) ;; ff storing profiling info
                    (tc (get prof 'tc #false))      ;; normal thread scheduler
                    (prof (del prof 'tc)))         ;; give just the collected data to thread
-                  (tc tc (cons (tuple id (λ () (cont prof))) todo) done 
+                  (tc tc (cons (tuple id (λ () (cont prof))) todo) done
                      (del state 'prof))))
 
             ; 22, nestable parallel computation
@@ -302,14 +302,14 @@
 
             ; 23, link thread
             (λ (id cont target c todo done state tc)
-               (lets 
+               (lets
                   ((links (get state link-tag empty))
                    (followers (get links target null))
                    (links
                      (if (has? followers id)
                         links
                         (put links target (cons id followers)))))
-                  (tc tc 
+                  (tc tc
                      (cons (tuple id (λ () (cont target))) todo)
                      done
                      (put state link-tag links))))
@@ -355,7 +355,7 @@
                            (if (null? done)
                               (halt-thread-controller state)
                               (self self done null state))
-                           (lets 
+                           (lets
                               ((this todo todo)
                                (id st this)
                                (state (update-state state st))
@@ -365,20 +365,20 @@
                                  (self self todo (cons (tuple id a) done) state)
                                  ((ref mcp-syscalls-during-profiling op) id a b c todo done state self))))) ; <- difference here
 
-                     (scheduler scheduler (cons (tuple id (λ () (cont 'started-profiling))) todo) done 
+                     (scheduler scheduler (cons (tuple id (λ () (cont 'started-profiling))) todo) done
                         (put state 'prof           ;; profiling data is stored under key 'prof
                            (put empty 'tc tc)))))) ;; store normal scheduler there for resuming on syscall 21
              (syscalls
                (set syscalls 21 ;; end-profiling syscall doesn't do anything when not profiling
-                  (λ (id cont b c todo done state tc) 
+                  (λ (id cont b c todo done state tc)
                      (tc tc (cons (tuple id (λ () (cont 'not-profiling-you-fool))) todo) done state)))))
             syscalls))
 
       (define (enter-mcp controller threads state)
          ; could break here also when threads is just repl-input
          (controller controller
-            (list 
-               (tuple 'mcp 
+            (list
+               (tuple 'mcp
                   (λ ()
                      ((get state signal-tag signal-halt) ; exit by default
                         threads state controller))))
@@ -414,13 +414,13 @@
                      (lets ((op a b c (run state thread-quantum)))
                         (cond
                            ((eq? op 1) ;; out of time, a is new state
-                              (values #false 
+                              (values #false
                                  (tuple cont todo (cons a done))))
                            ((eq? op 2) ;; finished, return value and thunk to continue computation
                               (values #true
                                  (λ () (cont (cons a (λ () (syscall 22 todo done)))))))
                            ((eq? op 22) ;; start nested parallel computation
-                              (lets ((contp a) (todop b) (donep c) 
+                              (lets ((contp a) (todop b) (donep c)
                                      (por-state (tuple contp todop donep)))
                                  (values #false
                                     (tuple cont todo (cons por-state done)))))
@@ -434,7 +434,7 @@
             (if (null? done)
                (halt-thread-controller state)  ;; nothing left to run
                (self self done null state))    ;; new scheduler round
-            (lets 
+            (lets
                ((this todo todo)
                 (id st this))
                (lets ((op a b c (run st thread-quantum)))

--- a/tests/bingo-rand.scm
+++ b/tests/bingo-rand.scm
@@ -49,7 +49,7 @@
 (thread 'fini
    (begin
       (print (ref (wait-mail) 2)) ; omit the id to make output equal in all cases
-      (for-each (c mail 'halt) (drop-mails))))
+      (for-each (C mail 'halt) (drop-mails))))
 
 (fold
    (λ (rst id)
@@ -61,4 +61,4 @@
    (iota 0 1 n))
 
 ;; start all threads
-(for-each (c mail 'start) (iota 0 1 n))
+(for-each (C mail 'start) (iota 0 1 n))

--- a/tests/lazy.scm
+++ b/tests/lazy.scm
@@ -9,7 +9,7 @@
 (print (force-ll (ltake (ledit editor (lnums 1)) 20)))
 
 
-;; start checking laziness/eagerness preservation 
+;; start checking laziness/eagerness preservation
 
 (define (boom . tail)
    (lambda ()
@@ -25,9 +25,7 @@
       ((function? x) 'TBC)
       (else 'ERROR)))
 
-(define print-computed 
-   (o print computed))
-
-;; 
+(define print-computed
+   (B print computed))
 
 (print-computed three-elems)

--- a/tests/mail-async-rand.scm
+++ b/tests/mail-async-rand.scm
@@ -43,4 +43,4 @@
    (seed->rands (* (time-ms) (<< (time-ms) 9)))
    (iota 0 2 n-threads))
 
-(for-each (c mail 'start) (iota 0 1 n-threads))
+(for-each (C mail 'start) (iota 0 1 n-threads))

--- a/tests/rlist-rand.scm
+++ b/tests/rlist-rand.scm
@@ -12,14 +12,14 @@
 (define max-list-size 10000)
 
 ; run a battery of operations to a list and an equal rlist
-; and stop on inconsistencies 
+; and stop on inconsistencies
 
 (define (list-test rst rl l len steps)
 	(if (= steps 0)
 		(print "ok")
 		(lets ((rst n (rand rst 25))
 				 (steps (- steps 1)))
-			;; draw a graph of the list length 
+			;; draw a graph of the list length
 			;(mail stdout (fold (lambda (out n) (cons 45 out)) '(124 10) (iota 0 1 len)))
 			(case n
 				((0 1 2) ; cons a new head
@@ -27,7 +27,7 @@
 						(lets ((rst x (rand rst 1000)))
 							(list-test rst (rcons x rl) (cons x l) (+ len 1) steps))
 						(list-test rst rl l len steps)))
-				((3 4 5) ; drop a head, slightly less frequent 
+				((3 4 5) ; drop a head, slightly less frequent
 					(if (= len 0)
 						(list-test rst rl l len steps)
 						(list-test rst (rcdr rl) (cdr l) (- len 1) steps)))
@@ -46,8 +46,8 @@
 							(list-test rst (rset rl p v) (lset l p v) len steps))))
 				((11) ; map increment
 					(list-test rst
-						(rmap (c + 1) rl)
-						(map (c + 1) l)
+						(rmap (C + 1) rl)
+						(map (C + 1) l)
 						len steps))
 				((12) ; fold
 					(if (= (fold - 0 l) (rfold - 0 rl))


### PR DESCRIPTION
as discussed in #55