### PR TITLE
miscellaneous changes regarding  lists

### DIFF
--- a/owl/compile.scm
+++ b/owl/compile.scm
@@ -443,7 +443,7 @@
       (define (opcode->primop op)
          (let
             ((node
-               (some
+               (any
                   (λ (x) (if (eq? (ref x 2) op) x #false))
                   primops)))
             (if node node (error "Unknown primop: " op))))

--- a/owl/list.scm
+++ b/owl/list.scm
@@ -9,7 +9,7 @@
       mem
       fold-map foldr-map
       append reverse keep remove
-      all any
+      every any
       smap unfold
       take-while                ;; pred, lst -> as, bs
       fold2
@@ -230,8 +230,8 @@
             (keep null? l) = '(() ())
             (remove null? l) = '(1 2 3 4)))
 
-      (define (all pred lst)
-         (or (null? lst) (and (pred (car lst)) (all pred (cdr lst)))))
+      (define (every pred lst)
+         (or (null? lst) (and (pred (car lst)) (every pred (cdr lst)))))
 
       (define (any pred lst)
          (and (pair? lst) (or (pred (car lst)) (any pred (cdr lst)))))
@@ -239,7 +239,7 @@
       (let ((l '(#t #f ())))
          (example
             (any null? l) = #true
-            (all null? l) = #false))
+            (every null? l) = #false))
 
       ; map carrying one state variable down like fold
       (define (smap op st lst)

--- a/owl/list.scm
+++ b/owl/list.scm
@@ -9,7 +9,7 @@
       mem
       fold-map foldr-map
       append reverse keep remove
-      all some
+      all any
       smap unfold
       take-while                ;; pred, lst -> as, bs
       fold2
@@ -233,12 +233,12 @@
       (define (all pred lst)
          (or (null? lst) (and (pred (car lst)) (all pred (cdr lst)))))
 
-      (define (some pred lst)
-         (and (pair? lst) (or (pred (car lst)) (some pred (cdr lst)))))
+      (define (any pred lst)
+         (and (pair? lst) (or (pred (car lst)) (any pred (cdr lst)))))
 
       (let ((l '(#t #f ())))
          (example
-            (some null? l) = #true
+            (any null? l) = #true
             (all null? l) = #false))
 
       ; map carrying one state variable down like fold

--- a/owl/macro.scm
+++ b/owl/macro.scm
@@ -220,13 +220,6 @@
          ;; -> keyword literals patterns templates
          (H match `(quote syntax-operation add #false (,symbol? ,list? ,list? ,list?))))
 
-      ; fold w/ 2 state variables
-      (define (fold2 op s1 s2 lst)
-         (if (null? lst)
-            (values s1 s2)
-            (lets ((s1 s2 (op s1 s2 (car lst))))
-               (fold2 op s1 s2 (cdr lst)))))
-
       (define (add-fresh-bindings names free dict)
          (fold2
             (λ (free dict name)

--- a/owl/macro.scm
+++ b/owl/macro.scm
@@ -228,7 +228,7 @@
 
       (define (make-transformer literals rules)
          (λ (form free)
-            (some
+            (any
                (λ (rule)
                   ;; rule = (pattern gensyms template)
                   (let ((dictionary (try-pattern (car rule) literals form)))

--- a/owl/math-extra.scm
+++ b/owl/math-extra.scm
@@ -176,9 +176,7 @@
                   (else (loop (expt-mod y 2 n) (+ j 1)))))))
 
       (define (miller-rabin-cases-ok? num tests)
-         (fold
-            (lambda (status a) (and status (miller-rabin num a)))
-            #true tests))
+         (every (H miller-rabin num) tests))
 
       (define assume-riemann-hypothesis? #true)
 

--- a/owl/repl.scm
+++ b/owl/repl.scm
@@ -242,7 +242,7 @@
    ,quit             - exit owl")
 
       (define (symbols? exp)
-         (and (list? exp) (all symbol? exp)))
+         (and (list? exp) (every symbol? exp)))
 
       (define (repl-op repl op in env)
          (case op
@@ -400,7 +400,7 @@
       ;; ((a b) ...)
       (define (pairs? exp)
          (and (list? exp)
-            (all (λ (x) (and (list? x) (= (length x) 2))) exp)))
+            (every (λ (x) (and (list? x) (= (length x) 2))) exp)))
 
       ;; → 'ok env | 'needed name | 'circular name, non-ok exists via fail
       (define (import-set->library iset libs fail)
@@ -467,7 +467,7 @@
 
       ;; nonempty list of symbols or integers
       (define (valid-library-name? x)
-         (and (list? x) (pair? x) (all (λ (x) (or (integer? x) (symbol? x))) x)))
+         (and (pair? x) (list? x) (every (λ (x) (or (integer? x) (symbol? x))) x)))
 
       ;; try to load a library based on it's name and current include prefixes if
       ;; it is required by something being loaded and we don't have it yet
@@ -530,7 +530,7 @@
             ((and (headed? 'not req) (= (length req) 2))
                (not (match-feature (cadr req) feats libs fail)))
             ((headed? 'and req)
-               (all (λ (req) (match-feature req feats libs fail)) (cdr req)))
+               (every (λ (req) (match-feature req feats libs fail)) (cdr req)))
             ((headed? 'or req)
                (any (λ (req) (match-feature req feats libs fail)) (cdr req)))
             (else

--- a/owl/repl.scm
+++ b/owl/repl.scm
@@ -41,7 +41,7 @@
       (define (fail reason) (tuple 'fail reason))
 
       (define (name->func name)
-         (some
+         (any
             (λ (x) (if (eq? (ref x 1) name) (ref x 5) #false))
             primops))
 
@@ -532,7 +532,7 @@
             ((headed? 'and req)
                (all (λ (req) (match-feature req feats libs fail)) (cdr req)))
             ((headed? 'or req)
-               (some (λ (req) (match-feature req feats libs fail)) (cdr req)))
+               (any (λ (req) (match-feature req feats libs fail)) (cdr req)))
             (else
                (fail "Weird feature requirement: " req))))
 

--- a/owl/symbol.scm
+++ b/owl/symbol.scm
@@ -13,7 +13,7 @@
 
    (import
       (owl defmac)
-      (only (owl list) all)
+      (only (owl list) every)
       (owl string)
       (only (owl syscall) error interact))
 
@@ -26,7 +26,7 @@
          (eq? (type x) type-symbol))
 
       (define (symbol=? x . lst)
-         (and (symbol? x) (all (C eq? x) lst)))
+         (and (symbol? x) (every (C eq? x) lst)))
 
       (define (symbol->string x)
          (if (symbol? x)

--- a/owl/sys.scm
+++ b/owl/sys.scm
@@ -388,9 +388,7 @@
       ;; list->tuple + internal conversion might also be worth doing in sys-arg instead
       (define (exec path args)
          (lets ((args (map c-string args)))
-            (if (all self args)
-               (sys 17 path args)
-               #false)))
+            (and (every self args) (sys 17 path args))))
 
       ;; → #false on failure, else '(read-port . write-port)
       (define (pipe)


### PR DESCRIPTION
While the definitions of `any` and `every` in Owl are not fully compatible to SRFI-1 (taking only one list, and `every` returns `#t` instead of the last `pred` result), I think that it still makes sense to use the names with these simple definitions (which probably cover the most common use case), as Schemers might better understand what this is about at the first view, and external Scheme code might benefit from it, too.